### PR TITLE
Store combat history

### DIFF
--- a/Assets/Scripts/System/Gameplay/RoundData.cs
+++ b/Assets/Scripts/System/Gameplay/RoundData.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class RoundData : ScriptableObject
+{
+    private int _moveIdPlayer1;
+    private int _moveIdPlayer2;
+    private int _damageToPlayer1;
+    private int _damageToPlayer2;
+
+    public int MoveIdPlayer1 { get => _moveIdPlayer1; set => _moveIdPlayer1 = value; }
+    public int MoveIdPlayer2 { get => _moveIdPlayer2; set => _moveIdPlayer2 = value; }
+    public int DamageToPlayer1 { get => _damageToPlayer1; set => _damageToPlayer1 = value; }
+    public int DamageToPlayer2 { get => _damageToPlayer2; set => _damageToPlayer2 = value; }
+
+    public RoundData ()
+    {
+        _moveIdPlayer1 = -1;
+        _moveIdPlayer2 = -1;
+        _damageToPlayer1 = 0;
+        _damageToPlayer2 = 0;
+    }
+}

--- a/Assets/Scripts/System/Gameplay/RoundData.cs.meta
+++ b/Assets/Scripts/System/Gameplay/RoundData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8aa7ae37d395f942ba1bfd7641ff998
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Gameplay/RoundDataBuilder.cs
+++ b/Assets/Scripts/System/Gameplay/RoundDataBuilder.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+public class RoundDataBuilder
+{
+    private RoundData _roundData;
+
+    public void StartNewRoundData()
+    {
+        _roundData = ScriptableObject.CreateInstance<RoundData>();
+    }
+
+    public void SetMoveIdPlayer1(int moveId = -1)
+    {
+        _roundData.MoveIdPlayer1 = moveId;
+    }
+
+    public void SetMoveIdPlayer2(int moveId = -1)
+    {
+        _roundData.MoveIdPlayer2 = moveId;
+    }
+
+    public void SetDamageToPlayer1(int value = 0)
+    {
+        _roundData.DamageToPlayer1 = value;
+    }
+
+    public void SetDamageToPlayer2(int value = 0)
+    {
+        _roundData.DamageToPlayer2 = value;
+    }
+
+    public RoundData GetRoundData()
+    {
+        return _roundData;
+    }
+}

--- a/Assets/Scripts/System/Gameplay/RoundDataBuilder.cs.meta
+++ b/Assets/Scripts/System/Gameplay/RoundDataBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e83b3c2c105763f42be4b15324a92aef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds functionality to record the history of each round using a `RoundData` data class and a builder pattern. Can be extended in the future for any other data points that need to be recorded for each round, but for now only stores move IDs and health change for each player.

![image](https://user-images.githubusercontent.com/55548523/234125270-b2fe38c7-7602-4a47-a8ae-d7c57476a64f.png)
