### PR TITLE
Fixed issue in build that was affecting NetworkVariable initialization in GameData

### DIFF
--- a/Assets/Prefabs/Gameplay/CharacterSpawner.prefab
+++ b/Assets/Prefabs/Gameplay/CharacterSpawner.prefab
@@ -9,8 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 258632379866117608}
-  - component: {fileID: 258632379866117609}
-  - component: {fileID: 258632379866117606}
   m_Layer: 0
   m_Name: CharacterSpawner
   m_TagString: Untagged
@@ -35,37 +33,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &258632379866117609
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258632379866117607}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd31e72bebea7e749b17661492b0487e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _characterDatabase: {fileID: 11400000, guid: 49d2dde0aecdb5c45ab502278e6c37f5, type: 2}
-  _player1SpawnLocation: {fileID: 5549924436977438012}
-  _player2SpawnLocation: {fileID: 7983645134942176123}
---- !u!114 &258632379866117606
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258632379866117607}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
 --- !u!1 &5549924436977438012
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Gameplay/GameSystems.prefab
+++ b/Assets/Prefabs/Gameplay/GameSystems.prefab
@@ -1,0 +1,451 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2046045532550530866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2046045532550530831}
+  - component: {fileID: 2046045532550530829}
+  - component: {fileID: 2046045532550530828}
+  - component: {fileID: 4808603526597705746}
+  - component: {fileID: 6346495220142219102}
+  - component: {fileID: 1392871768440727446}
+  m_Layer: 0
+  m_Name: GameSystems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2046045532550530831
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046045532550530866}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7584809055976174916}
+  - {fileID: 5868780935207684780}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2046045532550530829
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046045532550530866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!114 &2046045532550530828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046045532550530866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2747cae1430670a4f99ba30de62c7f48, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _characterDatabase: {fileID: 11400000, guid: 49d2dde0aecdb5c45ab502278e6c37f5, type: 2}
+  _characterMoveDatabase: {fileID: 11400000, guid: 2c1b0dd1acd15bc4d813b3033b33f460, type: 2}
+  _characterSpawner: {fileID: 1392871768440727446}
+  _baseDamage: 10
+  _baseSpecialGain: 25
+  _gameUIManager: {fileID: 6346495220142219102}
+--- !u!114 &4808603526597705746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046045532550530866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5ea1d11f6fa3e5459e3bee87ff07ced, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _gameStartDuration: 3
+  _roundActiveDuration: 8
+  _roundResolveDuration: 5
+  _timer: 0
+  _gameUIManager: {fileID: 6346495220142219102}
+--- !u!114 &6346495220142219102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046045532550530866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d4b36c5a3ee6c14aaf0234ea084ba87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _data: {fileID: 2046045532550530828}
+  _player1ComboContainer: {fileID: 1000905880199938529}
+  _player2ComboContainer: {fileID: 3402007012660589590}
+  _playerControls: {fileID: 2664796269131360072}
+  _player1Health: {fileID: 3078376556297747457}
+  _player2Health: {fileID: 7692169740761271873}
+  _player1SpecialMeter: {fileID: 2325100053949072714}
+  _player2SpecialMeter: {fileID: 8335035956172947285}
+  _roundResult: {fileID: 5420172140006227797}
+  _gameResult: {fileID: 1634927369112202182}
+  _roundTimer: {fileID: 7584809054794018895}
+  _player1ComboCountText: {fileID: 1670353688537363615}
+  _player2ComboCountText: {fileID: 8043245136111834542}
+  _player1Name: {fileID: 7584809054084181376}
+  _player2Name: {fileID: 7584809054354881115}
+--- !u!114 &1392871768440727446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046045532550530866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd31e72bebea7e749b17661492b0487e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _characterDatabase: {fileID: 11400000, guid: 49d2dde0aecdb5c45ab502278e6c37f5, type: 2}
+  _player1SpawnLocation: {fileID: 2297270336208122488}
+  _player2SpawnLocation: {fileID: 4336785153204943935}
+  _gameData: {fileID: 2046045532550530828}
+  _gameUIManager: {fileID: 6346495220142219102}
+--- !u!1001 &1433958247469596285
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2046045532550530831}
+    m_Modifications:
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8837424539488652093, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+      propertyPath: m_Name
+      value: GameUI
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+--- !u!1 &1000905880199938529 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2163311074558902172, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1634927369112202182 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 384526335031481787, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a18ac4c2d5f74e4d9e8bc8b206f58e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1670353688537363615 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 344587742298163938, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2325100053949072714 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3720566219519753015, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2664796269131360072 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3971387050715175221, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5bebba78af859584193231af02b25519, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3078376556297747457 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4133994699384865404, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3402007012660589590 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4382048856400923243, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5420172140006227797 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6403591684774461736, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 361ef213a962ca54081e4aeea61f4b8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7584809054084181376 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8837424539243647997, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7584809054354881115 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8837424538973602854, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7584809054794018895 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8837424538372492850, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3147b15b7a62a394e847f8720b0baa8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &7584809055976174916 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7692169740761271873 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8729773721058750524, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8043245136111834542 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8969246018713365459, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8335035956172947285 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6939359174801309992, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
+  m_PrefabInstance: {fileID: 1433958247469596285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &5973112233259368260
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2046045532550530831}
+    m_Modifications:
+    - target: {fileID: 258632379866117607, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_Name
+      value: CharacterSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+--- !u!1 &2297270336208122488 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5549924436977438012, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+  m_PrefabInstance: {fileID: 5973112233259368260}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4336785153204943935 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7983645134942176123, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+  m_PrefabInstance: {fileID: 5973112233259368260}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &5868780935207684780 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+  m_PrefabInstance: {fileID: 5973112233259368260}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Gameplay/GameSystems.prefab.meta
+++ b/Assets/Prefabs/Gameplay/GameSystems.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f47ee9b25f7a1d44f9269fb5da138ac4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Gameplay/GameUI.prefab
+++ b/Assets/Prefabs/Gameplay/GameUI.prefab
@@ -4235,8 +4235,6 @@ GameObject:
   - component: {fileID: 8837424539488652090}
   - component: {fileID: 8837424539488652091}
   - component: {fileID: 8837424539488652092}
-  - component: {fileID: 8837424539488652088}
-  - component: {fileID: 8837424539488652087}
   m_Layer: 5
   m_Name: GameUI
   m_TagString: Untagged
@@ -4330,49 +4328,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &8837424539488652088
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8837424539488652093}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
---- !u!114 &8837424539488652087
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8837424539488652093}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d4b36c5a3ee6c14aaf0234ea084ba87, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _data: {fileID: 0}
-  _player1ComboContainer: {fileID: 2163311074558902172}
-  _player2ComboContainer: {fileID: 4382048856400923243}
-  _playerControls: {fileID: 3971387050715175221}
-  _player1Health: {fileID: 4133994699384865404}
-  _player2Health: {fileID: 8729773721058750524}
-  _player1SpecialMeter: {fileID: 3720566219519753015}
-  _player2SpecialMeter: {fileID: 6939359174801309992}
-  _roundResult: {fileID: 6403591684774461736}
-  _gameResult: {fileID: 384526335031481787}
-  _roundTimer: {fileID: 8837424538372492850}
-  _player1ComboCountText: {fileID: 344587742298163938}
-  _player2ComboCountText: {fileID: 8969246018713365459}
-  _player1Name: {fileID: 8837424539243647997}
-  _player2Name: {fileID: 8837424538973602854}
 --- !u!1 &8837424539509850905
 GameObject:
   m_ObjectHideFlags: 0
@@ -5130,17 +5085,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
---- !u!114 &3720566219519753015 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 252962688212648808, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
-  m_PrefabInstance: {fileID: 3467964652160104543}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &8095268498052930929 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4645608927789573422, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
@@ -5279,17 +5223,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
---- !u!114 &4133994699384865404 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 252962688212648808, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
-  m_PrefabInstance: {fileID: 4241355655505051924}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &8837424540171559994 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4645608927789573422, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
@@ -5909,17 +5842,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4645608927789573422, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
   m_PrefabInstance: {fileID: 7192031308333613632}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6939359174801309992 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 252962688212648808, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
-  m_PrefabInstance: {fileID: 7192031308333613632}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &8837424540001735801
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6179,14 +6101,3 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4645608927789573422, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
   m_PrefabInstance: {fileID: 8837424540090430292}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &8729773721058750524 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 252962688212648808, guid: 57ff66e2a390ab74ea079be25922c616, type: 3}
-  m_PrefabInstance: {fileID: 8837424540090430292}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f3b3015410552fb4dba3547606d91da3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -123,82 +123,13 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &1416120
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 9136673535173169991, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_Name
-      value: GameStateMachine
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170040, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 392044955
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170041, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: _gameUIManager
-      value: 
-      objectReference: {fileID: 1944409255}
-    - target: {fileID: 9136673535173170041, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: _roundActiveDuration
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 327.4995
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 344
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9136673535173170042, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 84432dfb02614cf47a315b5c32c11dd7, type: 3}
 --- !u!43 &258360843
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1372
+  m_Name: pb_Mesh158942
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -362,7 +293,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1302
+  m_Name: pb_Mesh159650
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -526,7 +457,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1274
+  m_Name: pb_Mesh159374
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -697,7 +628,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8623778637195841406, guid: a6cad1a5524e65546aff70574d98bc82, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8623778637195841406, guid: a6cad1a5524e65546aff70574d98bc82, type: 3}
       propertyPath: m_LocalPosition.x
@@ -869,82 +800,74 @@ PrefabInstance:
       objectReference: {fileID: 1777758309}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a6cad1a5524e65546aff70574d98bc82, type: 3}
---- !u!1001 &969648151
+--- !u!1001 &1144685131
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 258632379866117606, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530829, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: GlobalObjectIdHash
-      value: 4057557172
+      value: 448966445
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117607, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
-      propertyPath: m_Name
-      value: CharacterSpawner
-      objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117608, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+    - target: {fileID: 2046045532550530831, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 258632379866117609, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
-      propertyPath: _gameData
-      value: 
-      objectReference: {fileID: 2041224490}
-    - target: {fileID: 258632379866117609, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
-      propertyPath: _gameUIManager
-      value: 
-      objectReference: {fileID: 1944409255}
+    - target: {fileID: 2046045532550530866, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
+      propertyPath: m_Name
+      value: GameSystems
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 204824d83bf87f842b922e2fe8f3a705, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: f47ee9b25f7a1d44f9269fb5da138ac4, type: 3}
 --- !u!43 &1183755633
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1316
+  m_Name: pb_Mesh159204
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1184,7 +1107,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 1.5, y: 0, z: 0}
 --- !u!1 &1313614203
 GameObject:
@@ -1223,7 +1146,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1288
+  m_Name: pb_Mesh159106
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1387,7 +1310,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1358
+  m_Name: pb_Mesh159672
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1574,7 +1497,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &1777758309
 Mesh:
@@ -1582,7 +1505,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1344
+  m_Name: pb_Mesh159802
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1740,221 +1663,13 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1001 &1944409254
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4133994699384865404, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: current
-      value: 78.56
-      objectReference: {fileID: 0}
-    - target: {fileID: 4596436010798172143, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_Interactable
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652087, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: _data
-      value: 
-      objectReference: {fileID: 2041224490}
-    - target: {fileID: 8837424539488652088, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 2173010871
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652089, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8837424539488652093, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-      propertyPath: m_Name
-      value: GameUI
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
---- !u!114 &1944409255 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8837424539488652087, guid: 58895870a849e964f9e252009d9e1eb7, type: 3}
-  m_PrefabInstance: {fileID: 1944409254}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d4b36c5a3ee6c14aaf0234ea084ba87, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &2041224489
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 395.33252
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 351.01584
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.1404027
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714832, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714837, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: m_Name
-      value: GameData
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714838, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 1009703202
-      objectReference: {fileID: 0}
-    - target: {fileID: 5712701981712714839, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: _gameUIManager
-      value: 
-      objectReference: {fileID: 1944409255}
-    - target: {fileID: 5712701981712714839, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: _characterDatabase
-      value: 
-      objectReference: {fileID: 11400000, guid: 49d2dde0aecdb5c45ab502278e6c37f5, type: 2}
-    - target: {fileID: 5712701981712714839, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-      propertyPath: _gameplayUIManager
-      value: 
-      objectReference: {fileID: 1944409255}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
---- !u!114 &2041224490 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5712701981712714839, guid: 9b2f7292ceac0eb4ca73df84f4b7d87a, type: 3}
-  m_PrefabInstance: {fileID: 2041224489}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2747cae1430670a4f99ba30de62c7f48, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!43 &2078665240
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-1330
+  m_Name: pb_Mesh159530
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2125,7 +1840,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4607836152022744082, guid: 6a12f8c003db1bb4e849b1aeebdbf000, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4607836152022744082, guid: 6a12f8c003db1bb4e849b1aeebdbf000, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2240,5 +1955,5 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/System/Gameplay/CharacterSpawner.cs
+++ b/Assets/Scripts/System/Gameplay/CharacterSpawner.cs
@@ -19,6 +19,7 @@ public class CharacterSpawner : NetworkBehaviour
         {
             return;
         }
+        Debug.Log("CharacterSpawner OnNetworkSpawn");
 
         foreach (var client in ServerManager.Instance.ClientData)
         {

--- a/Assets/Scripts/System/Gameplay/GameData.cs
+++ b/Assets/Scripts/System/Gameplay/GameData.cs
@@ -13,49 +13,50 @@ public class GameData : NetworkBehaviour
 
     [SerializeField] private CharacterDatabase _characterDatabase;
     [SerializeField] private CharacterMoveDatabase _characterMoveDatabase;
-    [SerializeField] private GameUIManager _gameUIManager;
+    [SerializeField] private CharacterSpawner _characterSpawner;
     [SerializeField] private float _baseDamage = 10f;
     [SerializeField] private float _baseSpecialGain = 25f;
-    private int _characterIdPlayer1;
-    private int _characterIdPlayer2;
+    [SerializeField] private GameUIManager _gameUIManager;
+    private bool _displayDebugMenu = false;
     private Character _characterPlayer1;
     private Character _characterPlayer2;
+    private int _characterIdPlayer1;
+    private int _characterIdPlayer2;
+    private List<CombatCommandBase> _combatCommands;
+    private List<RoundData> _roundDataList;
     private NetworkVariable<byte> _usableMoveListPlayer1 = new(0);
     private NetworkVariable<byte> _usableMoveListPlayer2 = new(0);
+    private NetworkVariable<float> _healthPlayer1 = new(0);
+    private NetworkVariable<float> _healthPlayer2 = new(0);
+    private NetworkVariable<float> _specialMeterPlayer1 = new(0);
+    private NetworkVariable<float> _specialMeterPlayer2 = new(0);
     private NetworkVariable<int> _actionPlayer1 = new(-1);
     private NetworkVariable<int> _actionPlayer2 = new(-1);
     private NetworkVariable<int> _comboCountPlayer1 = new(0);
     private NetworkVariable<int> _comboCountPlayer2 = new(0);
-    private NetworkVariable<float> _healthPlayer1 = new();
-    private NetworkVariable<float> _healthPlayer2 = new();
     private NetworkVariable<int> _roundNumber = new(0);
-    private NetworkVariable<float> _specialMeterPlayer1 = new(0);
-    private NetworkVariable<float> _specialMeterPlayer2 = new(0);
     private NetworkVariable<ulong> _clientIdPlayer1 = new(9999);
     private NetworkVariable<ulong> _clientIdPlayer2 = new(9999);
     private RoundDataBuilder _roundDataBuilder;
-    private List<RoundData> _roundDataList;
-    private List<CombatCommandBase> _combatCommands;
-    private bool _displayDebugMenu = false;
 
+    public CharacterMoveDatabase CharacterMoveDatabase { get { return _characterMoveDatabase; } }
     public int CharacterIdPlayer1 { get; set; }
     public int CharacterIdPlayer2 { get; set; }
+    public List<CombatCommandBase> CombatCommands { get { return _combatCommands; } }
+    public List<RoundData> RoundDataList { get { return _roundDataList; } }
     public NetworkVariable<byte> UsableMoveListPlayer1 { get { return _usableMoveListPlayer1; } }
     public NetworkVariable<byte> UsableMoveListPlayer2 { get { return _usableMoveListPlayer2; } }
+    public NetworkVariable<float> HealthPlayer1 { get { return _healthPlayer1; } }
+    public NetworkVariable<float> HealthPlayer2 { get { return _healthPlayer2; } }
+    public NetworkVariable<float> SpecialMeterPlayer1 { get { return _specialMeterPlayer1; } }
+    public NetworkVariable<float> SpecialMeterPlayer2 { get { return _specialMeterPlayer2; } }
     public NetworkVariable<int> ActionPlayer1 { get { return _actionPlayer1; } }
     public NetworkVariable<int> ActionPlayer2 { get { return _actionPlayer2; } }
     public NetworkVariable<int> ComboCountPlayer1 { get { return _comboCountPlayer1; } }
     public NetworkVariable<int> ComboCountPlayer2 { get { return _comboCountPlayer2; } }
-    public NetworkVariable<float> HealthPlayer1 { get { return _healthPlayer1; } }
-    public NetworkVariable<float> HealthPlayer2 { get { return _healthPlayer2; } }
     public NetworkVariable<int> RoundNumber { get { return _roundNumber; } }
-    public NetworkVariable<float> SpecialMeterPlayer1 { get { return _specialMeterPlayer1; } }
-    public NetworkVariable<float> SpecialMeterPlayer2 { get { return _specialMeterPlayer2; } }
     public NetworkVariable<ulong> ClientIdPlayer1 { get { return _clientIdPlayer1; } set { _clientIdPlayer1 = value; } }
     public NetworkVariable<ulong> ClientIdPlayer2 { get { return _clientIdPlayer2; } set { _clientIdPlayer2 = value; } }
-    public List<CombatCommandBase> CombatCommands { get { return _combatCommands; } }
-    public CharacterMoveDatabase CharacterMoveDatabase { get { return _characterMoveDatabase; } }
-    public List<RoundData> RoundDataList { get { return _roundDataList; } }
 
     private void Awake()
     {
@@ -73,6 +74,7 @@ public class GameData : NetworkBehaviour
     public override void OnNetworkSpawn()
     {
         if (!IsServer) return;
+        Debug.Log("GameData OnNetworkSpawn");
 
         _roundDataBuilder = new RoundDataBuilder();
         _roundDataList = new List<RoundData>();

--- a/ProjectSettings/BurstAotSettings_StandaloneWindows.json
+++ b/ProjectSettings/BurstAotSettings_StandaloneWindows.json
@@ -12,6 +12,6 @@
     "CpuMaxTargetX64": 0,
     "CpuTargetsX32": 6,
     "CpuTargetsX64": 72,
-    "OptimizeFor": 0
+    "OptimizeFor": 4
   }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -667,7 +667,7 @@ PlayerSettings:
   webGLDecompressionFallback: 0
   webGLPowerPreference: 2
   scriptingDefineSymbols:
-    Standalone: MIRROR;MIRROR_57_0_OR_NEWER;MIRROR_58_0_OR_NEWER;MIRROR_65_0_OR_NEWER;MIRROR_66_0_OR_NEWER;MIRROR_2022_9_OR_NEWER;MIRROR_2022_10_OR_NEWER;MIRROR_70_0_OR_NEWER;MIRROR_71_0_OR_NEWER;MIRROR_73_OR_NEWER
+    Standalone: 
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}


### PR DESCRIPTION
I was initially worried that something related to compiler optimization was breaking my management of game state. Instead, I discovered that the lifecycle methods of two different components were being called in different orders in the build and the editor. Resolved the issue by unifying all of the game systems (`GameData`, `GameUIManager`, `GameStateMachine`, and `CharacterSpawner`) under a single network object to synchronize and control their initialization. Issue has been fixed.