### PR TITLE
Track player movement with camera

### DIFF
--- a/Assets/Level/Characters/1_Character/1_Character_NetPrefab.prefab
+++ b/Assets/Level/Characters/1_Character/1_Character_NetPrefab.prefab
@@ -335,6 +335,7 @@ GameObject:
   - component: {fileID: 6172530370408940432}
   - component: {fileID: -1378166976225564033}
   - component: {fileID: -1172461933645140030}
+  - component: {fileID: -63338717337129222}
   m_Layer: 0
   m_Name: 1_Character_NetPrefab
   m_TagString: Untagged
@@ -448,6 +449,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _knockIncrement: 0.75
+--- !u!114 &-63338717337129222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1792858871355532953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
 --- !u!1 &1895598232985727677
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Characters/2_Character/2_Character_NetPrefab.prefab
+++ b/Assets/Level/Characters/2_Character/2_Character_NetPrefab.prefab
@@ -1557,6 +1557,7 @@ GameObject:
   - component: {fileID: 3285454599512250818}
   - component: {fileID: -727763050672013099}
   - component: {fileID: 4944484814470092715}
+  - component: {fileID: -3390191929331344083}
   m_Layer: 0
   m_Name: 2_Character_NetPrefab
   m_TagString: Untagged
@@ -1669,6 +1670,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _knockIncrement: 0.75
+--- !u!114 &-3390191929331344083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6408663707308932787}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
 --- !u!1 &6511961552124586647
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Characters/3_Character/3_Character_NetPrefab.prefab
+++ b/Assets/Level/Characters/3_Character/3_Character_NetPrefab.prefab
@@ -1333,6 +1333,7 @@ GameObject:
   - component: {fileID: 1797432619412505299}
   - component: {fileID: -3896960060548154663}
   - component: {fileID: 670597537693121539}
+  - component: {fileID: -7024827394319007704}
   m_Layer: 0
   m_Name: 3_Character_NetPrefab
   m_TagString: Untagged
@@ -1445,6 +1446,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _knockIncrement: 0.75
+--- !u!114 &-7024827394319007704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5224542780197023098}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
 --- !u!1 &5345292073556556126
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Prefabs/Gameplay/CMVirtualCamMain.prefab
+++ b/Assets/Level/Prefabs/Gameplay/CMVirtualCamMain.prefab
@@ -1,0 +1,168 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2354053876995331165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8271574756048530759}
+  - component: {fileID: 86002512662082643}
+  m_Layer: 0
+  m_Name: CMVirtualCamMain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8271574756048530759
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2354053876995331165}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5935987548688828938}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &86002512662082643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2354053876995331165}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 5935987548688828938}
+--- !u!1 &5162498191853783846
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5935987548688828938}
+  - component: {fileID: 5656272630633196719}
+  - component: {fileID: 1295480024020000024}
+  - component: {fileID: 7202912470112774399}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5935987548688828938
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5162498191853783846}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8271574756048530759}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5656272630633196719
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5162498191853783846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1295480024020000024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5162498191853783846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &7202912470112774399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5162498191853783846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0

--- a/Assets/Level/Prefabs/Gameplay/CMVirtualCamMain.prefab.meta
+++ b/Assets/Level/Prefabs/Gameplay/CMVirtualCamMain.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b0f3cc1da19f11f498419b0009c5aaeb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Prefabs/Gameplay/CameraFocusObject.prefab
+++ b/Assets/Level/Prefabs/Gameplay/CameraFocusObject.prefab
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2839060569122472849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8730385946482115773}
+  - component: {fileID: 5847529067584243850}
+  - component: {fileID: 3047418775138887202}
+  - component: {fileID: 217476178506472604}
+  m_Layer: 0
+  m_Name: CameraFocusObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8730385946482115773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839060569122472849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5847529067584243850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839060569122472849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a5ace329142d3d4593be297f134d195, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3047418775138887202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839060569122472849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 1
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 1
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  InLocalSpace: 0
+  Interpolate: 1
+--- !u!114 &217476178506472604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839060569122472849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1

--- a/Assets/Level/Prefabs/Gameplay/CameraFocusObject.prefab.meta
+++ b/Assets/Level/Prefabs/Gameplay/CameraFocusObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e4e89d501c655e8428ebcbaf26a0906f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Gameplay.unity
+++ b/Assets/Level/Scenes/Gameplay.unity
@@ -123,6 +123,72 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &38651449
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 217476178506472604, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2151777245
+      objectReference: {fileID: 0}
+    - target: {fileID: 2839060569122472849, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_Name
+      value: CameraFocusObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+--- !u!4 &38651450 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8730385946482115773, guid: e4e89d501c655e8428ebcbaf26a0906f, type: 3}
+  m_PrefabInstance: {fileID: 38651449}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &163744810
 GameObject:
   m_ObjectHideFlags: 0
@@ -198,7 +264,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &258360843
 Mesh:
@@ -1113,6 +1179,7 @@ GameObject:
   - component: {fileID: 1300989750}
   - component: {fileID: 1300989749}
   - component: {fileID: 1300989748}
+  - component: {fileID: 1300989751}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1178,14 +1245,48 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1300989746}
-  m_LocalRotation: {x: 0.013089582, y: 0, z: 0, w: 0.99991435}
-  m_LocalPosition: {x: 0, y: 1, z: -1}
+  m_LocalRotation: {x: 0.12218327, y: -0.000000017077465, z: 0.0000000021023319, w: 0.9925076}
+  m_LocalPosition: {x: 0, y: 1, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 1.5, y: 0, z: 0}
+--- !u!114 &1300989751
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1300989746}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 1
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 3
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1313614203
 GameObject:
   m_ObjectHideFlags: 0
@@ -2034,3 +2135,150 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &6882808223917983589
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 86002512662082643, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_Follow
+      value: 
+      objectReference: {fileID: 38651450}
+    - target: {fileID: 86002512662082643, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LookAt
+      value: 
+      objectReference: {fileID: 38651450}
+    - target: {fileID: 86002512662082643, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_Transitions.m_BlendHint
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 86002512662082643, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_Transitions.m_OnCameraLive.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 86002512662082643, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_Transitions.m_OnCameraLive.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 86002512662082643, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_Transitions.m_OnCameraLive.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1295480024020000024, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_HorizontalDamping
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1295480024020000024, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_TrackedObjectOffset.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2163619905690427143, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2163619905690427143, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2163619905690427143, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2163619905690427143, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2163619905690427143, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2163619905690427143, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2354053876995331165, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_Name
+      value: CMVirtualCamMain
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202912470112774399, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_XDamping
+      value: 2.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202912470112774399, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_FollowOffset.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202912470112774399, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_FollowOffset.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9925076
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.12218327
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.000000017077465
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.0000000021023319
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+--- !u!1 &6882808223917983590 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5162498191853783846, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
+  m_PrefabInstance: {fileID: 6882808223917983589}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6882808223917983591
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6882808223917983590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NoiseProfile: {fileID: 11400000, guid: 46965f9cbaf525742a6da4c2172a99cd, type: 2}
+  m_PivotOffset: {x: 0, y: 0, z: 0}
+  m_AmplitudeGain: 1
+  m_FrequencyGain: 1
+  mNoiseOffsets: {x: -343.1567, y: -679.9717, z: -595.12}

--- a/Assets/Resources/Tests/CameraFocusObjectTester.prefab
+++ b/Assets/Resources/Tests/CameraFocusObjectTester.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2839060569122472849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8730385946482115773}
+  - component: {fileID: 5847529067584243850}
+  m_Layer: 0
+  m_Name: CameraFocusObjectTester
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8730385946482115773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839060569122472849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5847529067584243850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839060569122472849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a5ace329142d3d4593be297f134d195, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Tests/CameraFocusObjectTester.prefab.meta
+++ b/Assets/Resources/Tests/CameraFocusObjectTester.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 284e2a68d306cba49938f1567f925880
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Installers/GameplayInstaller.cs
+++ b/Assets/Scripts/Core/Installers/GameplayInstaller.cs
@@ -10,6 +10,12 @@ public class GameplayInstaller : MonoInstaller
             .AsSingle()
             .NonLazy();
 
+        Container.Bind<ICameraFocusObject>()
+            .To<CameraFocusObject>()
+            .FromComponentInHierarchy()
+            .AsSingle()
+            .NonLazy();
+
         Container.Bind<ITurnHistory>()
             .To<TurnHistory>()
             .FromComponentInHierarchy()

--- a/Assets/Scripts/Gameplay/CameraFocusObject.cs
+++ b/Assets/Scripts/Gameplay/CameraFocusObject.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraFocusObject : MonoBehaviour, ICameraFocusObject
+{
+    private readonly List<Transform> _targets = new();
+
+    void Update()
+    {
+        if (_targets.Count == 0)
+        {
+            return;
+        }
+
+        Vector3 cumulativePosition = Vector3.zero;
+        foreach (Transform t in _targets)
+        {
+            cumulativePosition += t.position;
+        }
+        var targetPosition = cumulativePosition / _targets.Count;
+        transform.position = targetPosition;
+    }
+
+    public void AddTarget(Transform t)
+    {
+        _targets.Add(t);
+        Debug.Log($"Camera targets ({_targets.Count}): {string.Join(", ", _targets)}");
+    }
+
+    public void RemoveTarget(Transform t)
+    {
+        _targets.Remove(t);
+    }
+}

--- a/Assets/Scripts/Gameplay/CameraFocusObject.cs.meta
+++ b/Assets/Scripts/Gameplay/CameraFocusObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a5ace329142d3d4593be297f134d195
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/CharacterSpawner.cs
+++ b/Assets/Scripts/Gameplay/CharacterSpawner.cs
@@ -14,9 +14,17 @@ public class CharacterSpawner : NetworkBehaviour
     private IPlayerDataCollection _players;
     private CombatEvaluator _combatEvaluator;
     private ITurnHistory _turnHistory;
+    private ICameraFocusObject _cameraFocusObject;
 
     [Inject]
-    public void Construct(IGameUIManager gameUIManager, IServerManager serverManager, IDatabase database, IPlayerDataCollection players, CombatEvaluator combatEvaluator, ITurnHistory turnHistory)
+    public void Construct(
+        IGameUIManager gameUIManager,
+        IServerManager serverManager,
+        IDatabase database,
+        IPlayerDataCollection players,
+        CombatEvaluator combatEvaluator,
+        ITurnHistory turnHistory,
+        ICameraFocusObject cameraFocusObject)
     {
         _gameUIManager = gameUIManager;
         _serverManager = serverManager;
@@ -24,6 +32,7 @@ public class CharacterSpawner : NetworkBehaviour
         _players = players;
         _combatEvaluator = combatEvaluator;
         _turnHistory = turnHistory;
+        _cameraFocusObject = cameraFocusObject;
     }
 
     public override void OnNetworkSpawn()
@@ -70,5 +79,6 @@ public class CharacterSpawner : NetworkBehaviour
     {
         _players.RegisterPlayerCharacter(playerCharacter.PlayerNumber, clientId, playerCharacter);
         _gameUIManager.RegisterPlayerCharacter(playerCharacter.PlayerNumber, clientId);
+        _cameraFocusObject.AddTarget(playerCharacter.transform);
     }
 }

--- a/Assets/Scripts/Gameplay/GameStateMachine.cs
+++ b/Assets/Scripts/Gameplay/GameStateMachine.cs
@@ -74,4 +74,34 @@ public class GameStateMachine : NetworkBehaviour, IGameStateMachine
         _timerActive = true;
         _timerComplete = false;
     }
+
+#if !UNITY_INCLUDE_TESTS
+    void OnGUI()
+    {
+        if (!IsServer) return;
+        if (_players == null) return;
+
+        var player1 = _players.GetByPlayerNumber(1);
+        var player2 = _players.GetByPlayerNumber(2);
+
+        GUILayout.BeginArea(new Rect(20, 20, 100, 100));
+
+        if (GUILayout.Button("Knockback P1"))
+        {
+            player1.Position -= 1;
+            player2.Position += 1;
+            player1.PlayerMovementController.UpdatePosition();
+            player2.PlayerMovementController.UpdatePosition();
+        }        
+        if (GUILayout.Button("Knockback P2"))
+        {
+            player1.Position += 1;
+            player2.Position -= 1;
+            player1.PlayerMovementController.UpdatePosition();
+            player2.PlayerMovementController.UpdatePosition();
+        }
+
+        GUILayout.EndArea();
+    }
+#endif
 }

--- a/Assets/Scripts/Gameplay/ICameraFocusObject.cs
+++ b/Assets/Scripts/Gameplay/ICameraFocusObject.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+
+public interface ICameraFocusObject
+{
+    void AddTarget(Transform t);
+    void RemoveTarget(Transform t);
+}

--- a/Assets/Scripts/Gameplay/ICameraFocusObject.cs.meta
+++ b/Assets/Scripts/Gameplay/ICameraFocusObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e00a6720cf6ca946903d95a7a99a36b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Gameplay/CameraFocusObjectTest.cs
+++ b/Assets/Tests/Gameplay/CameraFocusObjectTest.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class CameraFocusObjectTest
+{
+    GameObject _testObject;
+    List<GameObject> _targets;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var prefab = (GameObject) Resources.Load("Tests/CameraFocusObjectTester");
+        _testObject = GameObject.Instantiate(prefab);
+
+        _targets = new List<GameObject>();
+
+        var target1 = new GameObject();
+        target1.transform.position = Vector3.left;
+        _targets.Add(target1);
+
+        var target2 = new GameObject();
+        target2.transform.position = Vector3.right;
+        _targets.Add(target2);
+
+        var target3 = new GameObject();
+        target3.transform.position = Vector3.up;
+        _targets.Add(target3);
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testObject.transform.position = Vector3.zero;
+    }
+
+    [UnityTest]
+    public IEnumerator CameraFocusObjectMovesToPositionInCenterOfOneTargets()
+    {
+        Vector3 expected = _targets[0].transform.position;
+        _testObject.GetComponent<CameraFocusObject>().AddTarget(_targets[0].transform);
+        yield return null;
+        Assert.AreEqual(expected, _testObject.transform.position);
+    }
+
+    [UnityTest]
+    public IEnumerator CameraFocusObjectMovesToPositionInCenterOfTwoTargets()
+    {
+        Vector3 expected = Vector3.zero;
+        expected += _targets[0].transform.position;
+        expected += _targets[1].transform.position;
+        expected /= 2;
+        _testObject.GetComponent<CameraFocusObject>().AddTarget(_targets[0].transform);
+        _testObject.GetComponent<CameraFocusObject>().AddTarget(_targets[1].transform);
+        yield return null;
+        Assert.AreEqual(expected, _testObject.transform.position);
+    }
+
+    [UnityTest]
+    public IEnumerator CameraFocusObjectMovesToPositionInCenterOfThreeTargets()
+    {
+        Vector3 expected = Vector3.zero;
+        expected += _targets[0].transform.position;
+        expected += _targets[1].transform.position;
+        expected += _targets[2].transform.position;
+        expected /= 3;
+        _testObject.GetComponent<CameraFocusObject>().AddTarget(_targets[0].transform);
+        _testObject.GetComponent<CameraFocusObject>().AddTarget(_targets[1].transform);
+        _testObject.GetComponent<CameraFocusObject>().AddTarget(_targets[2].transform);
+        yield return null;
+        Assert.AreEqual(expected, _testObject.transform.position);
+    }
+
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var t in _targets)
+        {
+            _testObject.GetComponent<CameraFocusObject>().RemoveTarget(t.transform);
+        }
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        GameObject.Destroy(_testObject);
+        for (int i =  _targets.Count - 1; i >= 0; i--)
+        {
+            GameObject.Destroy(_targets[i]);
+        }
+    }
+}

--- a/Assets/Tests/Gameplay/CameraFocusObjectTest.cs.meta
+++ b/Assets/Tests/Gameplay/CameraFocusObjectTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af88f81722696844194d94560740fe50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Gameplay/CharacterSpawnerTest.cs
+++ b/Assets/Tests/Gameplay/CharacterSpawnerTest.cs
@@ -40,6 +40,7 @@ public class CharacterSpawnerTest
             var serverManager = new Mock<IServerManager>();
             var combatEvaluator = new Mock<CombatEvaluator>();
             var turnHistory = new Mock<ITurnHistory>();
+            var cameraFocusObject = new Mock<ICameraFocusObject>();  
 
             // Setup Mocks
             _players
@@ -70,7 +71,8 @@ public class CharacterSpawnerTest
                 database: database.Object,
                 players: _players.Object,
                 combatEvaluator: combatEvaluator.Object,
-                turnHistory: turnHistory.Object);
+                turnHistory: turnHistory.Object,
+                cameraFocusObject: cameraFocusObject.Object);
 
             _characterSpawner.GetComponent<NetworkObject>().Spawn();
             yield return null;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.unity.cinemachine": "2.8.9",
     "com.unity.collab-proxy": "2.0.1",
     "com.unity.feature.2d": "1.0.0",
     "com.unity.feature.worldbuilding": "1.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -101,6 +101,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.cinemachine": {
+      "version": "2.8.9",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.31"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "2.0.1",
       "depth": 0,


### PR DESCRIPTION
Created the `CameraFocusObject`, which is a generic component that will set it's parent's transform to the center of a collection of target transforms in 3D space. Attached a cinemachine virtual camera to this focus object, and set the targets of the focus object to the two player characters.