### PR TITLE
Determine combo context

### DIFF
--- a/Assets/Level/Characters/1_Character/X Bot@Taunt.fbx.meta
+++ b/Assets/Level/Characters/1_Character/X Bot@Taunt.fbx.meta
@@ -31,7 +31,36 @@ ModelImporter:
     animationWrapMode: 0
     extraExposedTransformPaths: []
     extraUserProperties: []
-    clipAnimations: []
+    clipAnimations:
+    - serializedVersion: 16
+      name: Taunt
+      takeName: mixamo.com
+      internalID: -203655887218126122
+      firstFrame: 0
+      lastFrame: 170
+      wrapMode: 0
+      orientationOffsetY: 0
+      level: 0
+      cycleOffset: 0
+      loop: 0
+      hasAdditiveReferencePose: 0
+      loopTime: 0
+      loopBlend: 0
+      loopBlendOrientation: 0
+      loopBlendPositionY: 0
+      loopBlendPositionXZ: 0
+      keepOriginalOrientation: 0
+      keepOriginalPositionY: 1
+      keepOriginalPositionXZ: 0
+      heightFromFeet: 0
+      mirror: 0
+      bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+      curves: []
+      events: []
+      transformMask: []
+      maskType: 3
+      maskSource: {instanceID: 0}
+      additiveReferencePoseFrame: 0
     isReadable: 0
   meshes:
     lODScreenPercentages: []

--- a/Assets/Level/Characters/2_Character/2_Character.asset
+++ b/Assets/Level/Characters/2_Character/2_Character.asset
@@ -22,4 +22,4 @@ MonoBehaviour:
   _characterMoveSet: {fileID: 11400000, guid: 26b85bfecca86f14795f5e43670cd028, type: 2}
   _comboPathSet: {fileID: 11400000, guid: c4c4e1b97bdd3604b9c28a390859bc29, type: 2}
   _maximumHealth: 100
-  _effect: {fileID: -6011512517258168329, guid: a75a66e028d383c4eb68f0b72b32845c, type: 3}
+  _effect: {fileID: -727763050672013099, guid: a75a66e028d383c4eb68f0b72b32845c, type: 3}

--- a/Assets/Level/Characters/3_Character/3_Character.asset
+++ b/Assets/Level/Characters/3_Character/3_Character.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _introPrefab: {fileID: 5224542780197023098, guid: ba05c7bf8ad97214982fcbf06d7535ad, type: 3}
   _gameplayPrefab: {fileID: 3896857865105610499, guid: 1d74e6fe9c214804d8bcf07fff1d2bde, type: 3}
   _characterMoveSet: {fileID: 11400000, guid: fbc28392f5132fe4a9626a8b919f6237, type: 2}
+  _comboPathSet: {fileID: 11400000, guid: 2343d4fe376860443abd2ff923221678, type: 2}
   _maximumHealth: 100
-  _effect: {fileID: -8883395236232909719, guid: 1d74e6fe9c214804d8bcf07fff1d2bde, type: 3}
+  _effect: {fileID: -3896960060548154663, guid: 1d74e6fe9c214804d8bcf07fff1d2bde, type: 3}

--- a/Assets/Level/Characters/3_Character/3_ComboPath_Grab.asset
+++ b/Assets/Level/Characters/3_Character/3_ComboPath_Grab.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 3_ComboPath_Grab
   m_EditorClassIdentifier: 
-  _comboMove: 0
-  _freshComboMove: 0
+  _comboMove: 16
+  _freshComboMove: 8

--- a/Assets/Level/Characters/3_Character/3_ComboPath_Heavy.asset
+++ b/Assets/Level/Characters/3_Character/3_ComboPath_Heavy.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 3_ComboPath_Heavy
   m_EditorClassIdentifier: 
-  _comboMove: 0
-  _freshComboMove: 0
+  _comboMove: 16
+  _freshComboMove: 16

--- a/Assets/Level/Characters/3_Character/3_ComboPath_Light.asset
+++ b/Assets/Level/Characters/3_Character/3_ComboPath_Light.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 3_ComboPath_Light
   m_EditorClassIdentifier: 
-  _comboMove: 0
-  _freshComboMove: 0
+  _comboMove: 16
+  _freshComboMove: 2

--- a/Assets/Level/Characters/3_Character/3_ComboPath_Parry.asset
+++ b/Assets/Level/Characters/3_Character/3_ComboPath_Parry.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 3_ComboPath_Parry
   m_EditorClassIdentifier: 
-  _comboMove: 0
-  _freshComboMove: 0
+  _comboMove: 2
+  _freshComboMove: 16

--- a/Assets/Level/Scenes/Gameplay.unity
+++ b/Assets/Level/Scenes/Gameplay.unity
@@ -1245,7 +1245,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1300989746}
-  m_LocalRotation: {x: 0.12218327, y: -0.000000017077465, z: 0.0000000021023319, w: 0.9925076}
+  m_LocalRotation: {x: 0.12218325, y: 0.000000017077465, z: -0.0000000021023316, w: 0.9925076}
   m_LocalPosition: {x: 0, y: 1, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -2204,7 +2204,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7202912470112774399, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
       propertyPath: m_XDamping
-      value: 2.04
+      value: 8.6
       objectReference: {fileID: 0}
     - target: {fileID: 7202912470112774399, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
       propertyPath: m_FollowOffset.y
@@ -2236,15 +2236,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.12218327
+      value: 0.12218325
       objectReference: {fileID: 0}
     - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.000000017077465
+      value: 0.000000017077465
       objectReference: {fileID: 0}
     - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0000000021023319
+      value: -0.0000000021023316
       objectReference: {fileID: 0}
     - target: {fileID: 8271574756048530759, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2260,25 +2260,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
---- !u!1 &6882808223917983590 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5162498191853783846, guid: b0f3cc1da19f11f498419b0009c5aaeb, type: 3}
-  m_PrefabInstance: {fileID: 6882808223917983589}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6882808223917983591
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6882808223917983590}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 68bb026fafb42b14791938953eaace77, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_NoiseProfile: {fileID: 11400000, guid: 46965f9cbaf525742a6da4c2172a99cd, type: 2}
-  m_PivotOffset: {x: 0, y: 0, z: 0}
-  m_AmplitudeGain: 1
-  m_FrequencyGain: 1
-  mNoiseOffsets: {x: -343.1567, y: -679.9717, z: -595.12}

--- a/Assets/Scripts/Core/Data/Combo/ComboType.cs
+++ b/Assets/Scripts/Core/Data/Combo/ComboType.cs
@@ -1,0 +1,6 @@
+public enum ComboType
+{
+    Combo,
+    MixUp,
+    Normal
+}

--- a/Assets/Scripts/Core/Data/Combo/ComboType.cs.meta
+++ b/Assets/Scripts/Core/Data/Combo/ComboType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c22f34d2bec35194dbe40eb7dea48589
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Data/Player/IPlayerCharacter.cs
+++ b/Assets/Scripts/Core/Data/Player/IPlayerCharacter.cs
@@ -2,19 +2,20 @@
 
 public interface IPlayerCharacter
 {
-    int Action { get; set; }
+    bool ComboIsFresh { get; set; }
     Character Character { get; }
-    ulong ClientId { get; set; }
-    int ComboCount { get; set; }
     CharacterBaseEffect Effect { get; }
-    IGameUIManager GameUIManager { set; }
     float Health { get; set; }
-    PlayerData PlayerData { get; set; }
-    PlayerMovementController PlayerMovementController { get; }
+    float SpecialMeter { get; set; }
+    IGameUIManager GameUIManager { set; }
+    int Action { get; set; }
+    int ComboCount { get; set; }
     int PlayerNumber { get; set; }
     int Position { get; set; }
-    float SpecialMeter { get; set; }
     IUsableMoveSet UsableMoveSet { get; }
+    PlayerData PlayerData { get; set; }
+    PlayerMovementController PlayerMovementController { get; }
+    ulong ClientId { get; set; }
 
     void DecreaseHealth(float value);
     void IncreaseSpecialMeter(float value);

--- a/Assets/Scripts/Core/Data/Player/PlayerCharacter.cs
+++ b/Assets/Scripts/Core/Data/Player/PlayerCharacter.cs
@@ -53,7 +53,8 @@ public class PlayerCharacter : NetworkBehaviour, IPlayerCharacter
                 SpecialMeter = _playerData.SpecialMeter,
                 Action = _playerData.Action,
                 ComboCount = _playerData.ComboCount,
-                Position = _playerData.Position
+                Position = _playerData.Position,
+                ComboIsFresh = _playerData.ComboIsFresh
             };
         }
     }
@@ -73,7 +74,8 @@ public class PlayerCharacter : NetworkBehaviour, IPlayerCharacter
                 SpecialMeter = value,
                 Action = _playerData.Action,
                 ComboCount = _playerData.ComboCount,
-                Position = _playerData.Position
+                Position = _playerData.Position,
+                ComboIsFresh = _playerData.ComboIsFresh
             };
         }
     }
@@ -93,7 +95,8 @@ public class PlayerCharacter : NetworkBehaviour, IPlayerCharacter
                 SpecialMeter = _playerData.SpecialMeter,
                 Action = value,
                 ComboCount = _playerData.ComboCount,
-                Position = _playerData.Position
+                Position = _playerData.Position,
+                ComboIsFresh = _playerData.ComboIsFresh
             };
             var clientRpcParams = new ClientRpcParams
             {
@@ -121,7 +124,8 @@ public class PlayerCharacter : NetworkBehaviour, IPlayerCharacter
                 SpecialMeter = _playerData.SpecialMeter,
                 Action = _playerData.Action,
                 ComboCount = value,
-                Position = _playerData.Position
+                Position = _playerData.Position,
+                ComboIsFresh = _playerData.ComboIsFresh
             };
         }
     }
@@ -134,14 +138,34 @@ public class PlayerCharacter : NetworkBehaviour, IPlayerCharacter
         }
         set
         {
-            value = Mathf.Clamp(value, int.MinValue, int.MaxValue);
             _playerData = new PlayerData
             {
                 Health = _playerData.Health,
                 SpecialMeter = _playerData.SpecialMeter,
                 Action = _playerData.Action,
                 ComboCount = _playerData.ComboCount,
-                Position = value
+                Position = value,
+                ComboIsFresh = _playerData.ComboIsFresh
+            };
+        }
+    }
+
+    public bool ComboIsFresh
+    {
+        get
+        {
+            return _playerData.ComboIsFresh;
+        }
+        set
+        {
+            _playerData = new PlayerData
+            {
+                Health = _playerData.Health,
+                SpecialMeter = _playerData.SpecialMeter,
+                Action = _playerData.Action,
+                ComboCount = _playerData.ComboCount,
+                Position = _playerData.Position,
+                ComboIsFresh = value
             };
         }
     }

--- a/Assets/Scripts/Core/Data/Player/PlayerData.cs
+++ b/Assets/Scripts/Core/Data/Player/PlayerData.cs
@@ -9,14 +9,16 @@ public struct PlayerData : INetworkSerializable, IEquatable<PlayerData>
     public int Action;
     public int ComboCount;
     public int Position;
+    public bool ComboIsFresh;
 
-    public PlayerData(float health, float specialMeter = 0, int action = -1, int comboCount = 0, int position = 0)
+    public PlayerData(float health, float specialMeter = 0, int action = -1, int comboCount = 0, int position = 0, bool comboIsFresh = true)
     {
         Health = health;
         SpecialMeter = specialMeter;
         Action = action;
         ComboCount = comboCount;
         Position = position;
+        ComboIsFresh = comboIsFresh;
     }
 
     public bool Equals(PlayerData other)
@@ -25,7 +27,8 @@ public struct PlayerData : INetworkSerializable, IEquatable<PlayerData>
             SpecialMeter == other.SpecialMeter && 
             Action == other.Action && 
             ComboCount == other.ComboCount &&
-            Position == other.Position;
+            Position == other.Position &&
+            ComboIsFresh == other.ComboIsFresh;
     }
 
     public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
@@ -35,10 +38,11 @@ public struct PlayerData : INetworkSerializable, IEquatable<PlayerData>
         serializer.SerializeValue(ref Action);
         serializer.SerializeValue(ref ComboCount);
         serializer.SerializeValue(ref Position);
+        serializer.SerializeValue(ref ComboIsFresh);
     }
 
     public override string ToString()
     {
-        return $"{{Health: {Health}, Special: {SpecialMeter}, Action: {Action}, Combo: {ComboCount}, Postion: {Position}}}";
+        return $"{{Health: {Health}, Special: {SpecialMeter}, Action: {Action}, Combo: {ComboCount}, Postion: {Position}, Fresh: {ComboIsFresh}}}";
     }
 }

--- a/Assets/Scripts/Gameplay/CombatEvaluator.cs
+++ b/Assets/Scripts/Gameplay/CombatEvaluator.cs
@@ -45,8 +45,17 @@ public class CombatEvaluator
 
     public TurnData EvaluateTurnCombat()
     {
+        #region Setup
         _turnNumber += 1;
+        var damageToPlayer1 = 0f;
+        var damageToPlayer2 = 0f;
+        var positionChangePlayer1 = 0;
+        var positionChangePlayer2 = 0;
+        var special1 = _baseSpecialGain;
+        var special2 = _baseSpecialGain;
+        #endregion
 
+        #region Pulling Data
         var playerCharacter1 = _players.GetByPlayerNumber(1);
         var playerCharacter2 = _players.GetByPlayerNumber(2);
 
@@ -54,54 +63,52 @@ public class CombatEvaluator
         {
             throw new Exception("Failed to get playerCharacter objects");
         }
-
-        // Preliminary damage and special calculations
-        var damageToPlayer1 = 0f;
-        var damageToPlayer2 = 0f;
-        var positionChangePlayer1 = 0;
-        var positionChangePlayer2 = 0;
-        var special1 = _baseSpecialGain;
-        var special2 = _baseSpecialGain;
-
-        // Read Inputs
         var action1 = playerCharacter1.PlayerData.Action;
         var action2 = playerCharacter2.PlayerData.Action;
         var movePlayer1 = _database.Moves.GetMoveById(action1);
         var movePlayer2 = _database.Moves.GetMoveById(action2);
+        #endregion
 
-        // Evaluate winner
+        #region Determine Winner
+        // _database, movePlayer1, movePlayer2
+
         var player1Wins = (movePlayer2 == null) ||
             (movePlayer1 && _database.MoveInteractions.DefeatedByType(movePlayer1.MoveType).Contains(movePlayer2.MoveType));
         var player2Wins = (movePlayer1 == null) ||
             (movePlayer2 && _database.MoveInteractions.DefeatedByType(movePlayer2.MoveType).Contains(movePlayer1.MoveType));
+        #endregion
 
-        // Check combo context
+        #region Combo Context
+        // _database, _turnHistory, playerCharacter1, playerCharacter2
         bool player1IsInCombo = playerCharacter1.ComboCount > 0;
         bool player2IsInCombo = playerCharacter2.ComboCount > 0;
         ComboType player1ComboType = ComboType.Normal;
         ComboType player2ComboType = ComboType.Normal;
 
-        if (player1IsInCombo && TurnNumber > 0)
+        if (player1IsInCombo && TurnNumber > 0 && movePlayer1 != null)
         {
             var lastMovePlayer1 = _database.Moves.GetMoveById(_turnHistory.TurnDataList[^1].PlayerData1.Action);
             if (playerCharacter1.Character.ComboPathSet.TryGetValue(lastMovePlayer1.MoveType, out var player1ComboPath))
             {
-
                 if (playerCharacter1.ComboIsFresh)
                 {
                     if (player1ComboPath.FreshComboMove == movePlayer1.MoveType)
                     {
                         player1ComboType = ComboType.Combo;
                         playerCharacter1.ComboIsFresh = false;
+                        Debug.Log("Fresh Combo!");
                     }
                     else if (player1ComboPath.FreshMixUp.Contains<Move.Type>(movePlayer1.MoveType))
                     {
                         player1ComboType = ComboType.MixUp;
                         playerCharacter1.ComboIsFresh = true;
+                        Debug.Log("Fresh MixUp!");
                     }
                     else
                     {
                         playerCharacter1.ComboIsFresh = true;
+                        playerCharacter1.ResetComboCount();
+                        Debug.Log("Normal hit");
                     }
                 }
                 else
@@ -109,22 +116,32 @@ public class CombatEvaluator
                     if (player1ComboPath.ComboMove == movePlayer1.MoveType)
                     {
                         player1ComboType = ComboType.Combo;
-                        playerCharacter2.ComboIsFresh = false;
+                        playerCharacter1.ComboIsFresh = false;
+                        Debug.Log("Combo!");
                     }
                     else if (player1ComboPath.MixUp.Contains<Move.Type>(movePlayer1.MoveType))
                     {
                         player1ComboType = ComboType.MixUp;
-                        playerCharacter2.ComboIsFresh = true;
+                        playerCharacter1.ComboIsFresh = true;
+                        Debug.Log("MixUp!");
                     }
                     else
                     {
-                        playerCharacter2.ComboIsFresh = true;
+                        playerCharacter1.ComboIsFresh = true;
+                        playerCharacter1.ResetComboCount();
+                        Debug.Log("Normal hit");
                     }
                 }
             }
+            else
+            {
+                player1ComboType = ComboType.Combo;
+                playerCharacter1.ComboIsFresh = true;
+                Debug.Log("Special Combo!");
+            }
         }
 
-        if (player2IsInCombo && TurnNumber > 0)
+        if (player2IsInCombo && TurnNumber > 0 && movePlayer2 != null)
         {
             var lastMovePlayer2 = (TurnNumber > 0) ? _database.Moves.GetMoveById(_turnHistory.TurnDataList[^1].PlayerData2.Action) : null;
             if (playerCharacter2.Character.ComboPathSet.TryGetValue(lastMovePlayer2.MoveType, out var player2ComboPath))
@@ -135,10 +152,17 @@ public class CombatEvaluator
                     if (player2ComboPath.FreshComboMove == movePlayer2.MoveType)
                     {
                         player2ComboType = ComboType.Combo;
+                        playerCharacter2.ComboIsFresh = false;
                     }
                     else if (player2ComboPath.FreshMixUp.Contains<Move.Type>(movePlayer2.MoveType))
                     {
                         player2ComboType = ComboType.MixUp;
+                        playerCharacter2.ComboIsFresh = true;
+                    }
+                    else
+                    {
+                        playerCharacter2.ComboIsFresh = true;
+                        playerCharacter2.ResetComboCount();
                     }
                 }
                 else
@@ -146,22 +170,37 @@ public class CombatEvaluator
                     if (player2ComboPath.ComboMove == movePlayer2.MoveType)
                     {
                         player2ComboType = ComboType.Combo;
+                        playerCharacter2.ComboIsFresh = false;
                     }
                     else if (player2ComboPath.MixUp.Contains<Move.Type>(movePlayer2.MoveType))
                     {
                         player2ComboType = ComboType.MixUp;
+                        playerCharacter2.ComboIsFresh = true;
+                    }
+                    else
+                    {
+                        playerCharacter2.ComboIsFresh = true;
+                        playerCharacter2.ResetComboCount();
                     }
                 }
             }
+            else
+            {
+                player2ComboType = ComboType.Combo;
+                playerCharacter1.ComboIsFresh = true;
+                Debug.Log("Special Combo!");
+            }
         }
+        #endregion
 
-        // Check for specials   
+        #region Special evaluation
+        //movePlayer1, player1Wins, movePlayer2, player2Wins, playerCharacter1, playerCharacter2
         if ((movePlayer1 != null) && (movePlayer1.MoveType == Move.Type.Special))
         {
             playerCharacter1.Effect.DoSpecial(player1Wins && !player2Wins);
             playerCharacter1.SpecialMeter = 0f;
             special1 = 0;
-            playerCharacter1.ComboIsFresh = true;
+
         }
 
         if ((movePlayer2 != null) && (movePlayer2.MoveType == Move.Type.Special))
@@ -169,14 +208,14 @@ public class CombatEvaluator
             playerCharacter2.Effect.DoSpecial(!player1Wins && player2Wins);
             playerCharacter2.SpecialMeter = 0f;
             special2 = 0;
-            playerCharacter1.ComboIsFresh = true;
         }
+        #endregion
 
-        // Check who won and apply updates
+        #region Apply State Changes
         if (player1Wins && !player2Wins)
         {
-            positionChangePlayer1 = 1;
-            positionChangePlayer2 = -1;
+            positionChangePlayer1 = (playerCharacter1.PlayerData.Position < -1) ? 2 : 1;
+            positionChangePlayer2 = -1 * ((playerCharacter1.PlayerData.Position < -1) ? 2 : 1);
             damageToPlayer2 = _baseDamage;
             damageToPlayer2 *= player1ComboType switch
             {
@@ -190,8 +229,8 @@ public class CombatEvaluator
         }
         else if (!player1Wins && player2Wins)
         {
-            positionChangePlayer1 = -1;
-            positionChangePlayer2 = 1;
+            positionChangePlayer1 = -1 * ((playerCharacter2.PlayerData.Position < -1) ? 2 : 1);
+            positionChangePlayer2 = positionChangePlayer2 = (playerCharacter1.PlayerData.Position < -1) ? 2 : 1;
             damageToPlayer1 = _baseDamage;
             damageToPlayer1 *= player2ComboType switch
              {
@@ -201,7 +240,7 @@ public class CombatEvaluator
              };
             special1 *= _specialGainOnLossModifier;
             playerCharacter1.ResetComboCount();
-            playerCharacter1.IncrementComboCount();
+            playerCharacter2.IncrementComboCount();
         }
         else
         {
@@ -217,14 +256,16 @@ public class CombatEvaluator
         playerCharacter2.IncreaseSpecialMeter(special2);
         playerCharacter1.Position += positionChangePlayer1;
         playerCharacter2.Position += positionChangePlayer2;
+        #endregion region
 
-        // Execute queued commands
+        #region Execute Queued Commands
         foreach (CombatCommandBase command in _combatCommands.Where(c => c.Round == _turnNumber))
         {
             command.Execute(this);
         }
+        #endregion
 
-        // Check if specials should be enabled
+        #region Special state updates
         if (playerCharacter1.SpecialMeter >= 100f)
         {
             playerCharacter1.UsableMoveSet.EnableMoveByType(Move.Type.Special);
@@ -242,12 +283,9 @@ public class CombatEvaluator
         {
             playerCharacter2.UsableMoveSet.DisableMoveByType(Move.Type.Special);
         }
+        #endregion
 
-
-        // Update combo context
-        // TODO
-
-        // Log combat
+        #region Create TurnData
         var turnData = new TurnData
         {
             TurnNumber = _turnNumber,
@@ -257,14 +295,17 @@ public class CombatEvaluator
             DamageToPlayer2 = damageToPlayer2,
             Summary = GetResultString(player1Wins, player2Wins)
         };
+        #endregion
 
-        // Reset moves
+        #region Clear player input
         playerCharacter1.ResetAction();
         playerCharacter2.ResetAction();
-        
-        // Temporary
+        #endregion
+
+        #region Apply position updates
         playerCharacter1.PlayerMovementController.UpdatePosition();
         playerCharacter2.PlayerMovementController.UpdatePosition();
+        #endregion
 
         return turnData;
     }

--- a/Assets/Scripts/Gameplay/CombatEvaluator.cs
+++ b/Assets/Scripts/Gameplay/CombatEvaluator.cs
@@ -13,9 +13,11 @@ public class CombatEvaluator
     [SerializeField] private float _baseSpecialGain = 25f;
     [SerializeField] private float _chipDamageModifier = 0.5f;
     [SerializeField] private float _specialGainOnLossModifier = 0.35f;
+    [SerializeField] private float _comboDamageMultiplier = 1.5f;
 
     private IDatabase _database;
     private IPlayerDataCollection _players;
+    private ITurnHistory _turnHistory;
     private readonly List<CombatCommandBase> _combatCommands;
     private int _turnNumber = 0;
 
@@ -29,10 +31,11 @@ public class CombatEvaluator
     }
 
     [Inject]
-    public void Construct(IDatabase database, IPlayerDataCollection playerDataCollection)
+    public void Construct(IDatabase database, IPlayerDataCollection playerDataCollection, ITurnHistory turnHistory)
     {
         _database = database;
         _players = playerDataCollection;
+        _turnHistory = turnHistory;
     }
 
     public virtual void AddCombatCommand(CombatCommandBase combatCommand)
@@ -73,7 +76,84 @@ public class CombatEvaluator
             (movePlayer2 && _database.MoveInteractions.DefeatedByType(movePlayer2.MoveType).Contains(movePlayer1.MoveType));
 
         // Check combo context
-        // TODO
+        bool player1IsInCombo = playerCharacter1.ComboCount > 0;
+        bool player2IsInCombo = playerCharacter2.ComboCount > 0;
+        ComboType player1ComboType = ComboType.Normal;
+        ComboType player2ComboType = ComboType.Normal;
+
+        if (player1IsInCombo && TurnNumber > 0)
+        {
+            var lastMovePlayer1 = _database.Moves.GetMoveById(_turnHistory.TurnDataList[^1].PlayerData1.Action);
+            if (playerCharacter1.Character.ComboPathSet.TryGetValue(lastMovePlayer1.MoveType, out var player1ComboPath))
+            {
+
+                if (playerCharacter1.ComboIsFresh)
+                {
+                    if (player1ComboPath.FreshComboMove == movePlayer1.MoveType)
+                    {
+                        player1ComboType = ComboType.Combo;
+                        playerCharacter1.ComboIsFresh = false;
+                    }
+                    else if (player1ComboPath.FreshMixUp.Contains<Move.Type>(movePlayer1.MoveType))
+                    {
+                        player1ComboType = ComboType.MixUp;
+                        playerCharacter1.ComboIsFresh = true;
+                    }
+                    else
+                    {
+                        playerCharacter1.ComboIsFresh = true;
+                    }
+                }
+                else
+                {
+                    if (player1ComboPath.ComboMove == movePlayer1.MoveType)
+                    {
+                        player1ComboType = ComboType.Combo;
+                        playerCharacter2.ComboIsFresh = false;
+                    }
+                    else if (player1ComboPath.MixUp.Contains<Move.Type>(movePlayer1.MoveType))
+                    {
+                        player1ComboType = ComboType.MixUp;
+                        playerCharacter2.ComboIsFresh = true;
+                    }
+                    else
+                    {
+                        playerCharacter2.ComboIsFresh = true;
+                    }
+                }
+            }
+        }
+
+        if (player2IsInCombo && TurnNumber > 0)
+        {
+            var lastMovePlayer2 = (TurnNumber > 0) ? _database.Moves.GetMoveById(_turnHistory.TurnDataList[^1].PlayerData2.Action) : null;
+            if (playerCharacter2.Character.ComboPathSet.TryGetValue(lastMovePlayer2.MoveType, out var player2ComboPath))
+            {
+
+                if (playerCharacter2.ComboIsFresh)
+                {
+                    if (player2ComboPath.FreshComboMove == movePlayer2.MoveType)
+                    {
+                        player2ComboType = ComboType.Combo;
+                    }
+                    else if (player2ComboPath.FreshMixUp.Contains<Move.Type>(movePlayer2.MoveType))
+                    {
+                        player2ComboType = ComboType.MixUp;
+                    }
+                }
+                else
+                {
+                    if (player2ComboPath.ComboMove == movePlayer2.MoveType)
+                    {
+                        player2ComboType = ComboType.Combo;
+                    }
+                    else if (player2ComboPath.MixUp.Contains<Move.Type>(movePlayer2.MoveType))
+                    {
+                        player2ComboType = ComboType.MixUp;
+                    }
+                }
+            }
+        }
 
         // Check for specials   
         if ((movePlayer1 != null) && (movePlayer1.MoveType == Move.Type.Special))
@@ -81,22 +161,29 @@ public class CombatEvaluator
             playerCharacter1.Effect.DoSpecial(player1Wins && !player2Wins);
             playerCharacter1.SpecialMeter = 0f;
             special1 = 0;
+            playerCharacter1.ComboIsFresh = true;
         }
 
         if ((movePlayer2 != null) && (movePlayer2.MoveType == Move.Type.Special))
         {
             playerCharacter2.Effect.DoSpecial(!player1Wins && player2Wins);
             playerCharacter2.SpecialMeter = 0f;
-
             special2 = 0;
+            playerCharacter1.ComboIsFresh = true;
         }
 
         // Check who won and apply updates
         if (player1Wins && !player2Wins)
         {
-            damageToPlayer2 = _baseDamage;
             positionChangePlayer1 = 1;
             positionChangePlayer2 = -1;
+            damageToPlayer2 = _baseDamage;
+            damageToPlayer2 *= player1ComboType switch
+            {
+                ComboType.Combo => _comboDamageMultiplier,
+                ComboType.MixUp => _comboDamageMultiplier,
+                _ => 1.0f
+            };
             special2 *= _specialGainOnLossModifier;
             playerCharacter1.IncrementComboCount();
             playerCharacter2.ResetComboCount();
@@ -106,6 +193,12 @@ public class CombatEvaluator
             positionChangePlayer1 = -1;
             positionChangePlayer2 = 1;
             damageToPlayer1 = _baseDamage;
+            damageToPlayer1 *= player2ComboType switch
+             {
+                 ComboType.Combo => _comboDamageMultiplier,
+                 ComboType.MixUp => _comboDamageMultiplier,
+                 _ => 1.0f
+             };
             special1 *= _specialGainOnLossModifier;
             playerCharacter1.ResetComboCount();
             playerCharacter1.IncrementComboCount();

--- a/Assets/Tests/Core/PlayerCharacterAndDataTest.cs
+++ b/Assets/Tests/Core/PlayerCharacterAndDataTest.cs
@@ -114,6 +114,15 @@ public class PlayerCharacterAndDataTest
     }
 
     [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ComboIsFreshSetterChangesValueCorrectly(bool value)
+    {
+        _playerCharacter.ComboIsFresh = value;
+        Assert.AreEqual(value, _playerCharacter.ComboIsFresh);
+    }
+
+    [Test]
     [TestCase(1)]
     [TestCase(2)]
     public void SubmitPlayerActionServerRpcSetsActionAndSendsClientRpc(int value)


### PR DESCRIPTION
Added evaluation of combo context to `CombatEvaluator`, application of damage modifiers based on combo context, and updates to `PlayerData` to track combo state.

Closes #69 and #70 