### PR TITLE
86 highlight combo move

### DIFF
--- a/Assets/Level/Prefabs/Gameplay/GameUI.prefab
+++ b/Assets/Level/Prefabs/Gameplay/GameUI.prefab
@@ -5644,7 +5644,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 311021361504173924, guid: 12907a592773be94d89b1f2dc11ff8b7, type: 3}
       propertyPath: m_Interactable
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4637152139101508201, guid: 12907a592773be94d89b1f2dc11ff8b7, type: 3}
       propertyPath: m_Name

--- a/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
+++ b/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
@@ -29,7 +29,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 7886572335240391363}
   m_Father: {fileID: 6110243045511377234}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -211,6 +212,141 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &769119648802920239
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 577781308068371489}
+  - component: {fileID: 3472869809436145463}
+  - component: {fileID: 2575992003870713046}
+  m_Layer: 0
+  m_Name: Text (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &577781308068371489
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769119648802920239}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3785935700240159081}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -26}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3472869809436145463
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769119648802920239}
+  m_CullTransparentMesh: 1
+--- !u!114 &2575992003870713046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769119648802920239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Combo Move
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 5.74
+  m_fontSizeBase: 5.74
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2936960556460872905
 GameObject:
   m_ObjectHideFlags: 0
@@ -245,9 +381,144 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 6, y: 6}
+  m_AnchoredPosition: {x: 0, y: 3.5}
+  m_SizeDelta: {x: 0, y: 7}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3920120818823826447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7886572335240391363}
+  - component: {fileID: 543876771013538304}
+  - component: {fileID: 5840386180928383897}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7886572335240391363
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3920120818823826447}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2636149635960849089}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -26}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &543876771013538304
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3920120818823826447}
+  m_CullTransparentMesh: 1
+--- !u!114 &5840386180928383897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3920120818823826447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Enemy Combo Move
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 5.74
+  m_fontSizeBase: 5.74
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4541810501970301971
 GameObject:
   m_ObjectHideFlags: 0
@@ -473,8 +744,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 6, y: 6}
+  m_AnchoredPosition: {x: 0, y: 3.5}
+  m_SizeDelta: {x: 0, y: 7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5964907608351907537
 GameObject:
@@ -581,7 +852,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 577781308068371489}
   m_Father: {fileID: 1771131834457355078}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
+++ b/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
@@ -94,7 +94,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &904760030308921182
 RectTransform:
   m_ObjectHideFlags: 0
@@ -607,6 +607,7 @@ GameObject:
   - component: {fileID: 3667707413528675318}
   - component: {fileID: 311021361504173924}
   - component: {fileID: 6983177583962099486}
+  - component: {fileID: 9150606259674200790}
   m_Layer: 0
   m_Name: MoveButton
   m_TagString: Untagged
@@ -688,7 +689,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 628592723486498729}
+  m_TargetGraphic: {fileID: 9150606259674200790}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -710,6 +711,39 @@ MonoBehaviour:
   _highlight: {fileID: 5964907608351907537}
   _myComboIndicator: {fileID: 2936960556460872905}
   _enemyComboIndicator: {fileID: 4962342426870888337}
+  _myComboColor: {r: 1, g: 0.7537237, b: 0.09019607, a: 0}
+  _enemyComboColor: {r: 0.67058825, g: 0, b: 0.30699462, a: 0}
+  _defaultColor: {r: 1, g: 1, b: 1, a: 0}
+--- !u!114 &9150606259674200790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4637152139101508201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4962342426870888337
 GameObject:
   m_ObjectHideFlags: 0
@@ -935,7 +969,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 12}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 210, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2467264169473321802
@@ -1001,7 +1035,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 1024
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
+++ b/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
@@ -29,8 +29,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7886572335240391363}
+  m_Children: []
   m_Father: {fileID: 6110243045511377234}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -212,141 +211,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &769119648802920239
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 577781308068371489}
-  - component: {fileID: 3472869809436145463}
-  - component: {fileID: 2575992003870713046}
-  m_Layer: 0
-  m_Name: Text (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &577781308068371489
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 769119648802920239}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3785935700240159081}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -26}
-  m_SizeDelta: {x: 0, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3472869809436145463
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 769119648802920239}
-  m_CullTransparentMesh: 1
---- !u!114 &2575992003870713046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 769119648802920239}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Combo Move
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 5.74
-  m_fontSizeBase: 5.74
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2936960556460872905
 GameObject:
   m_ObjectHideFlags: 0
@@ -381,144 +245,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3.5}
-  m_SizeDelta: {x: 0, y: 7}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 8, y: 8}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &3920120818823826447
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7886572335240391363}
-  - component: {fileID: 543876771013538304}
-  - component: {fileID: 5840386180928383897}
-  m_Layer: 0
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7886572335240391363
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3920120818823826447}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2636149635960849089}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -26}
-  m_SizeDelta: {x: 0, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &543876771013538304
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3920120818823826447}
-  m_CullTransparentMesh: 1
---- !u!114 &5840386180928383897
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3920120818823826447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Enemy Combo Move
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 5.74
-  m_fontSizeBase: 5.74
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4541810501970301971
 GameObject:
   m_ObjectHideFlags: 0
@@ -607,7 +336,6 @@ GameObject:
   - component: {fileID: 3667707413528675318}
   - component: {fileID: 311021361504173924}
   - component: {fileID: 6983177583962099486}
-  - component: {fileID: 9150606259674200790}
   m_Layer: 0
   m_Name: MoveButton
   m_TagString: Untagged
@@ -689,7 +417,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 9150606259674200790}
+  m_TargetGraphic: {fileID: 628592723486498729}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -711,39 +439,6 @@ MonoBehaviour:
   _highlight: {fileID: 5964907608351907537}
   _myComboIndicator: {fileID: 2936960556460872905}
   _enemyComboIndicator: {fileID: 4962342426870888337}
-  _myComboColor: {r: 1, g: 0.7537237, b: 0.09019607, a: 0}
-  _enemyComboColor: {r: 0.67058825, g: 0, b: 0.30699462, a: 0}
-  _defaultColor: {r: 1, g: 1, b: 1, a: 0}
---- !u!114 &9150606259674200790
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4637152139101508201}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4962342426870888337
 GameObject:
   m_ObjectHideFlags: 0
@@ -778,8 +473,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3.5}
-  m_SizeDelta: {x: 0, y: 7}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 8, y: 8}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5964907608351907537
 GameObject:
@@ -886,8 +581,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 577781308068371489}
+  m_Children: []
   m_Father: {fileID: 1771131834457355078}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
+++ b/Assets/Level/Prefabs/Gameplay/MoveButton.prefab
@@ -1,5 +1,81 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &123788480908670703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2636149635960849089}
+  - component: {fileID: 4429098924257768590}
+  - component: {fileID: 6343872288162781494}
+  m_Layer: 0
+  m_Name: Image (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2636149635960849089
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 123788480908670703}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6110243045511377234}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4429098924257768590
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 123788480908670703}
+  m_CullTransparentMesh: 1
+--- !u!114 &6343872288162781494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 123788480908670703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.3806955, b: 0.2588235, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &634044396023363598
 GameObject:
   m_ObjectHideFlags: 0
@@ -31,7 +107,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4830886031930498986}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -135,6 +211,43 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2936960556460872905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1771131834457355078}
+  m_Layer: 0
+  m_Name: MyComboIndicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1771131834457355078
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2936960556460872905}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3785935700240159081}
+  m_Father: {fileID: 4830886031930498986}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 6, y: 6}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4541810501970301971
 GameObject:
   m_ObjectHideFlags: 0
@@ -166,7 +279,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4830886031930498986}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -242,6 +355,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 6110243045511377234}
+  - {fileID: 1771131834457355078}
   - {fileID: 6296393252604689623}
   - {fileID: 8387454508883544861}
   - {fileID: 1412509050244383387}
@@ -322,6 +437,45 @@ MonoBehaviour:
   _typeText: {fileID: 537138234599586723}
   _button: {fileID: 311021361504173924}
   _highlight: {fileID: 5964907608351907537}
+  _myComboIndicator: {fileID: 2936960556460872905}
+  _enemyComboIndicator: {fileID: 4962342426870888337}
+--- !u!1 &4962342426870888337
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6110243045511377234}
+  m_Layer: 0
+  m_Name: EnemyComboIndicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6110243045511377234
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4962342426870888337}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2636149635960849089}
+  m_Father: {fileID: 4830886031930498986}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 6, y: 6}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5964907608351907537
 GameObject:
   m_ObjectHideFlags: 0
@@ -353,12 +507,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4830886031930498986}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -5}
-  m_SizeDelta: {x: 0, y: 10}
+  m_AnchoredPosition: {x: 0, y: -2.5}
+  m_SizeDelta: {x: 0, y: 5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6727322364407512288
 CanvasRenderer:
@@ -382,6 +536,82 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.49803925, g: 0.9725491, b: 0.3529412, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6776760228273393498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3785935700240159081}
+  - component: {fileID: 7700610341730878352}
+  - component: {fileID: 161626590874205232}
+  m_Layer: 0
+  m_Name: Image (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3785935700240159081
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6776760228273393498}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1771131834457355078}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7700610341730878352
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6776760228273393498}
+  m_CullTransparentMesh: 1
+--- !u!114 &161626590874205232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6776760228273393498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.25943398, g: 0.47477865, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -429,7 +659,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4830886031930498986}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/Assets/Scripts/Core/Data/Moves/Move.cs
+++ b/Assets/Scripts/Core/Data/Moves/Move.cs
@@ -13,7 +13,8 @@ public class Move : ScriptableObject
         HeavyAttack = 8,
         Parry = 4,
         Grab = 2,
-        Special = 1
+        Special = 1,
+        None = 0
     }
 
     [SerializeField] private string _moveName;

--- a/Assets/Scripts/Core/Data/Player/UsableMoveSet.cs
+++ b/Assets/Scripts/Core/Data/Player/UsableMoveSet.cs
@@ -16,6 +16,11 @@ public class UsableMoveSet : NetworkBehaviour, IUsableMoveSet
     {
         foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
         {
+            var move = moveSet.GetMoveByType(type);
+            if (move == null)
+            {
+                continue;
+            }
             byte isUsable = (byte)(moveSet.GetMoveByType(type).UsableByDefault ? 1 : 0);
             byte typeAsByte = (byte)type;
             _moves.Value |= (byte)(typeAsByte * isUsable);

--- a/Assets/Scripts/Gameplay/GameStateMachine.cs
+++ b/Assets/Scripts/Gameplay/GameStateMachine.cs
@@ -92,23 +92,4 @@ public class GameStateMachine : NetworkBehaviour, IGameStateMachine
         _timerActive = true;
         _timerComplete = false;
     }
-
-    void OnGUI()
-    {
-        if (!IsServer) return;
-
-        GUILayout.BeginArea(new Rect(20, 20, 100, 100));
-
-        if (GUILayout.Button("Toggle Timer"))
-        {
-            if (!_timerActive)
-            {
-                _timer = _timerMax;
-            }
-            _timerActive = !_timerActive;
-        }        
-        GUILayout.Label($"Timer: {_timer:0.0}/{_timerMax}");
-
-        GUILayout.EndArea();
-    }
 }

--- a/Assets/Scripts/Gameplay/GameStateMachine.cs
+++ b/Assets/Scripts/Gameplay/GameStateMachine.cs
@@ -93,33 +93,22 @@ public class GameStateMachine : NetworkBehaviour, IGameStateMachine
         _timerComplete = false;
     }
 
-#if !UNITY_INCLUDE_TESTS
     void OnGUI()
     {
         if (!IsServer) return;
-        if (_players == null) return;
-
-        var player1 = _players.GetByPlayerNumber(1);
-        var player2 = _players.GetByPlayerNumber(2);
 
         GUILayout.BeginArea(new Rect(20, 20, 100, 100));
 
-        if (GUILayout.Button("Knockback P1"))
+        if (GUILayout.Button("Toggle Timer"))
         {
-            player1.Position -= 1;
-            player2.Position += 1;
-            player1.PlayerMovementController.UpdatePosition();
-            player2.PlayerMovementController.UpdatePosition();
+            if (!_timerActive)
+            {
+                _timer = _timerMax;
+            }
+            _timerActive = !_timerActive;
         }        
-        if (GUILayout.Button("Knockback P2"))
-        {
-            player1.Position += 1;
-            player2.Position -= 1;
-            player1.PlayerMovementController.UpdatePosition();
-            player2.PlayerMovementController.UpdatePosition();
-        }
+        GUILayout.Label($"Timer: {_timer:0.0}/{_timerMax}");
 
         GUILayout.EndArea();
     }
-#endif
 }

--- a/Assets/Scripts/Gameplay/State/GameTurnResolveState.cs
+++ b/Assets/Scripts/Gameplay/State/GameTurnResolveState.cs
@@ -34,6 +34,7 @@ public class GameTurnResolveState : GameBaseState
             .ApplyStateChanges()
             .ExecuteCombatCommands()
             .CheckAndSetSpecialUsability()
+            .DetermineNextComboMove()
             .GetTurnData();
         _context.TurnHistory.AddTurnData(turnResult);
         _context.Players.ResetActions();

--- a/Assets/Scripts/Gameplay/Turn.cs
+++ b/Assets/Scripts/Gameplay/Turn.cs
@@ -17,6 +17,8 @@ public class Turn
     public Move Player1Move;
     public Move Player2LastMove;
     public Move Player2Move;
+    public Move.Type Player1NextCombo;
+    public Move.Type Player2NextCombo;
     public ComboType Player1ComboType;
     public ComboType Player2ComboType;
     public IPlayerCharacter Player1;
@@ -138,6 +140,29 @@ public class Turn
         return this;
     }
 
+    public Turn DetermineNextComboMove()
+    {
+        Player1NextCombo = Move.Type.None;
+        Player2NextCombo = Move.Type.None;
+
+        if (Player1.ComboCount > 0)
+        {
+            if (Player1.Character.ComboPathSet.TryGetValue(Player1Move.MoveType, out var player1ComboPath))
+            {
+                Player1NextCombo = (Player1.ComboIsFresh) ? player1ComboPath.FreshComboMove : player1ComboPath.ComboMove;
+            }
+        }
+
+        if (Player2.ComboCount > 0)
+        {
+            if (Player2.Character.ComboPathSet.TryGetValue(Player2Move.MoveType, out var player2ComboPath))
+            {
+                Player2NextCombo = (Player2.ComboIsFresh) ? player2ComboPath.FreshComboMove : player2ComboPath.ComboMove;
+            }
+        }
+        return this;
+    }
+
     public TurnResult GetTurnData()
     {
         return new TurnResult
@@ -147,7 +172,9 @@ public class Turn
             PlayerData2 = Player2.PlayerData,
             DamageToPlayer1 = Player1DamageTaken,
             DamageToPlayer2 = Player2DamageTaken,
-            Summary = GetResultString()
+            Summary = GetResultString(),
+            Player1NextComboMove = Player1NextCombo,
+            Player2NextComboMove = Player2NextCombo
         };
     }
 

--- a/Assets/Scripts/Gameplay/TurnResult.cs
+++ b/Assets/Scripts/Gameplay/TurnResult.cs
@@ -10,6 +10,8 @@ public struct TurnResult : INetworkSerializable, IEquatable<TurnResult>
     public PlayerData PlayerData2;
     public float DamageToPlayer1;
     public float DamageToPlayer2;
+    public Move.Type Player1NextComboMove;
+    public Move.Type Player2NextComboMove;
     public FixedString32Bytes Summary;
 
     public TurnResult (
@@ -18,7 +20,9 @@ public struct TurnResult : INetworkSerializable, IEquatable<TurnResult>
         PlayerData playerData2,
         float damageToPlayer1,
         float damageToPlayer2,
-        FixedString32Bytes summary)
+        FixedString32Bytes summary,
+        Move.Type player1NextComboMove = Move.Type.None,
+        Move.Type player2NextComboMove = Move.Type.None)
     {
         TurnNumber = turnNumber;
         PlayerData1 = playerData1;
@@ -26,6 +30,9 @@ public struct TurnResult : INetworkSerializable, IEquatable<TurnResult>
         DamageToPlayer1 = damageToPlayer1;
         DamageToPlayer2 = damageToPlayer2;
         Summary = summary;
+        Player1NextComboMove = player1NextComboMove;
+        Player2NextComboMove = player2NextComboMove;
+
     }
 
     public bool Equals(TurnResult other)
@@ -41,10 +48,12 @@ public struct TurnResult : INetworkSerializable, IEquatable<TurnResult>
         serializer.SerializeValue(ref DamageToPlayer1);
         serializer.SerializeValue(ref DamageToPlayer2);
         serializer.SerializeValue(ref Summary);
+        serializer.SerializeValue(ref Player1NextComboMove);
+        serializer.SerializeValue(ref Player2NextComboMove);
     }
 
     public override string ToString()
     {
-        return $"[Turn {TurnNumber}]\nP1: {PlayerData1}\nP2: {PlayerData2}";
+        return $"[Turn {TurnNumber}]\nP1: {PlayerData1}\nP2: {PlayerData2}\nP1 Combo: {Player1NextComboMove}, P2 Combo: {Player2NextComboMove}";
     }
 }

--- a/Assets/Scripts/Gameplay/UI/GameUIManager.cs
+++ b/Assets/Scripts/Gameplay/UI/GameUIManager.cs
@@ -44,7 +44,7 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
     public override void OnNetworkDespawn()
     {
         _turnHistory.TurnDataList.OnListChanged -= HandleTurnData;
-        _localPlayerCharacter.UsableMoveSet.Moves.OnValueChanged += UpdateUsableMoveButtons;
+        _localPlayerCharacter.UsableMoveSet.Moves.OnValueChanged -= UpdateUsableMoveButtons;
     }
 
     private void HandleTurnData(NetworkListEvent<TurnResult> changeEvent)
@@ -67,7 +67,8 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
 
     private void DisplayComboIndicators(TurnResult turnData)
     {
-        var isMyCombo = DetermineIfLocalPlayerIsInCombo(turnData);
+        var isMyCombo = DetermineIfLocalPlayerIsInCombo();
+        var playerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
         if (isMyCombo)
         {
             var myLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
@@ -90,7 +91,7 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
         }
     }
 
-    private bool DetermineIfLocalPlayerIsInCombo(TurnResult turnData)
+    private bool DetermineIfLocalPlayerIsInCombo()
     {
         return _localPlayerCharacter.ComboCount > 0;
     }
@@ -152,7 +153,7 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
             _player1Health.SetMaximum(health);
             _player1Health.SetCurrent(health);
             _player1Name.text = $"Player 1 [{name}]";
-        }
+        } 
         else if (playerNumber == 2)
         {
             _player2Health.SetMaximum(health);

--- a/Assets/Scripts/Gameplay/UI/GameUIManager.cs
+++ b/Assets/Scripts/Gameplay/UI/GameUIManager.cs
@@ -69,35 +69,32 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
     {
         var localPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
         var otherPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData2 : turnData.PlayerData1;
+        var localNextComboType = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.Player1NextComboMove : turnData.Player2NextComboMove;
+        var otherNextComboType = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.Player2NextComboMove : turnData.Player1NextComboMove;
         var isMyCombo = localPlayerData.ComboCount > 0; 
         var isOtherCombo = otherPlayerData.ComboCount > 0;
         if (isMyCombo)
         {
-            var myLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
-            var myLastMove = _database.Moves.GetMoveById(myLastPlayerData.Action);
+            var myLastMove = _database.Moves.GetMoveById(localPlayerData.Action);
             if (myLastMove.MoveType == Move.Type.Special)
             {
                 _playerControls.SetComboHighlightForAllButtonsAfterSpecial(true);
             }
-            else if (_localPlayerCharacter.Character.ComboPathSet.TryGetValue(myLastMove.MoveType, out var comboPath))
+            else
             {
-                var comboMoveType = (myLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
-                _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
+                _playerControls.SetComboHighlight(localNextComboType, isMyCombo);
             }
         }
         else if (isOtherCombo)
         {
-            var opponentLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData2 : turnData.PlayerData1;
-            var opponentLastMove = _database.Moves.GetMoveById(opponentLastPlayerData.Action);
-            if (opponentLastMove.MoveType == Move.Type.Special)
+            var otherLastMove = _database.Moves.GetMoveById(otherPlayerData.Action);
+            if (otherLastMove.MoveType == Move.Type.Special)
             {
                 _playerControls.SetComboHighlightForAllButtonsAfterSpecial(false);
             }
-            // this doesn't work?
-            if (_players.GetByOpponentClientId(_localPlayerCharacter.ClientId).Character.ComboPathSet.TryGetValue(opponentLastMove.MoveType, out var comboPath))
+            else
             {
-                var comboMoveType = (opponentLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
-                _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
+                _playerControls.SetComboHighlight(otherNextComboType, isMyCombo);
             }
         }
         else
@@ -129,7 +126,11 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
     {
         foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
         {
-            _playerControls.GetButtonByType(type).Button.interactable = (newValue & (byte)type) == (byte)type;
+            var button = _playerControls.GetButtonByType(type);
+            if (button != null)
+            {
+                button.Button.interactable = (newValue & (byte)type) == (byte)type;
+            }
         }
     }
 

--- a/Assets/Scripts/Gameplay/UI/GameUIManager.cs
+++ b/Assets/Scripts/Gameplay/UI/GameUIManager.cs
@@ -75,7 +75,11 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
         {
             var myLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
             var myLastMove = _database.Moves.GetMoveById(myLastPlayerData.Action);
-            if (_localPlayerCharacter.Character.ComboPathSet.TryGetValue(myLastMove.MoveType, out var comboPath))
+            if (myLastMove.MoveType == Move.Type.Special)
+            {
+                _playerControls.SetComboHighlightForAllButtonsAfterSpecial(true);
+            }
+            else if (_localPlayerCharacter.Character.ComboPathSet.TryGetValue(myLastMove.MoveType, out var comboPath))
             {
                 var comboMoveType = (myLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
                 _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
@@ -85,7 +89,12 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
         {
             var opponentLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData2 : turnData.PlayerData1;
             var opponentLastMove = _database.Moves.GetMoveById(opponentLastPlayerData.Action);
-            if (_localPlayerCharacter.Character.ComboPathSet.TryGetValue(opponentLastMove.MoveType, out var comboPath))
+            if (opponentLastMove.MoveType == Move.Type.Special)
+            {
+                _playerControls.SetComboHighlightForAllButtonsAfterSpecial(false);
+            }
+            // this doesn't work?
+            if (_players.GetByOpponentClientId(_localPlayerCharacter.ClientId).Character.ComboPathSet.TryGetValue(opponentLastMove.MoveType, out var comboPath))
             {
                 var comboMoveType = (opponentLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
                 _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
@@ -95,11 +104,6 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
         {
             _playerControls.ClearComboHighlights();
         }
-    }
-
-    private bool DetermineIfLocalPlayerIsInCombo()
-    {
-        return _localPlayerCharacter.ComboCount > 0;
     }
 
     public void DisplayRoundResult(TurnResult turnData)

--- a/Assets/Scripts/Gameplay/UI/GameUIManager.cs
+++ b/Assets/Scripts/Gameplay/UI/GameUIManager.cs
@@ -60,8 +60,39 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
         UpdatePlayer2Special(playerData2.SpecialMeter);
         UpdatePlayer1Combo(playerData1.ComboCount);
         UpdatePlayer2Combo(playerData2.ComboCount);
-        DisplayRoundResult(turnData);
+        //DisplayRoundResult(turnData);
         _turnHistoryContent.AddTurnHistoryRow(turnData);
+        DisplayComboIndicators(turnData);
+    }
+
+    private void DisplayComboIndicators(TurnResult turnData)
+    {
+        var isMyCombo = DetermineIfLocalPlayerIsInCombo(turnData);
+        if (isMyCombo)
+        {
+            var myLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
+            var myLastMove = _database.Moves.GetMoveById(myLastPlayerData.Action);
+            if (_localPlayerCharacter.Character.ComboPathSet.TryGetValue(myLastMove.MoveType, out var comboPath))
+            {
+                var comboMoveType = (myLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
+                _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
+            }
+        }
+        else
+        {
+            var opponentLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData2 : turnData.PlayerData1;
+            var opponentLastMove = _database.Moves.GetMoveById(opponentLastPlayerData.Action);
+            if (_localPlayerCharacter.Character.ComboPathSet.TryGetValue(opponentLastMove.MoveType, out var comboPath))
+            {
+                var comboMoveType = (opponentLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
+                _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
+            }
+        }
+    }
+
+    private bool DetermineIfLocalPlayerIsInCombo(TurnResult turnData)
+    {
+        return _localPlayerCharacter.ComboCount > 0;
     }
 
     public void DisplayRoundResult(TurnResult turnData)

--- a/Assets/Scripts/Gameplay/UI/GameUIManager.cs
+++ b/Assets/Scripts/Gameplay/UI/GameUIManager.cs
@@ -67,8 +67,10 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
 
     private void DisplayComboIndicators(TurnResult turnData)
     {
-        var isMyCombo = DetermineIfLocalPlayerIsInCombo();
-        var playerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
+        var localPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
+        var otherPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData2 : turnData.PlayerData1;
+        var isMyCombo = localPlayerData.ComboCount > 0; 
+        var isOtherCombo = otherPlayerData.ComboCount > 0;
         if (isMyCombo)
         {
             var myLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData1 : turnData.PlayerData2;
@@ -79,7 +81,7 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
                 _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
             }
         }
-        else
+        else if (isOtherCombo)
         {
             var opponentLastPlayerData = (_localPlayerCharacter.PlayerNumber == 1) ? turnData.PlayerData2 : turnData.PlayerData1;
             var opponentLastMove = _database.Moves.GetMoveById(opponentLastPlayerData.Action);
@@ -88,6 +90,10 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
                 var comboMoveType = (opponentLastPlayerData.ComboIsFresh) ? comboPath.FreshComboMove : comboPath.ComboMove;
                 _playerControls.SetComboHighlight(comboMoveType, isMyCombo);
             }
+        }
+        else
+        {
+            _playerControls.ClearComboHighlights();
         }
     }
 

--- a/Assets/Scripts/Gameplay/UI/MoveButton.cs
+++ b/Assets/Scripts/Gameplay/UI/MoveButton.cs
@@ -48,10 +48,12 @@ public class MoveButton : MonoBehaviour
         if (isMyCombo)
         {
             _myComboIndicator.SetActive(true);
+            _enemyComboIndicator.SetActive(false);
         }
         else
         {
             _enemyComboIndicator.SetActive(true);
+            _myComboIndicator.SetActive(false);
         }
     }
 

--- a/Assets/Scripts/Gameplay/UI/MoveButton.cs
+++ b/Assets/Scripts/Gameplay/UI/MoveButton.cs
@@ -10,6 +10,8 @@ public class MoveButton : MonoBehaviour
     [SerializeField] TMP_Text _typeText;
     [SerializeField] Button _button;
     [SerializeField] private GameObject _highlight;
+    [SerializeField] private GameObject _myComboIndicator;
+    [SerializeField] private GameObject _enemyComboIndicator;
     private Move _move;
     private IGameUIManager _gameUIManager;
     
@@ -39,5 +41,23 @@ public class MoveButton : MonoBehaviour
     public void SetHighlight(bool value)
     {
         _highlight.SetActive(value);
+    }
+
+    public void SetMyComboIndicator(bool isMyCombo)
+    {
+        if (isMyCombo)
+        {
+            _myComboIndicator.SetActive(true);
+        }
+        else
+        {
+            _enemyComboIndicator.SetActive(true);
+        }
+    }
+
+    public void ClearComboIndicator()
+    {
+        _myComboIndicator.SetActive(false);
+        _enemyComboIndicator.SetActive(false);
     }
 }

--- a/Assets/Scripts/Gameplay/UI/PlayerControls.cs
+++ b/Assets/Scripts/Gameplay/UI/PlayerControls.cs
@@ -64,6 +64,22 @@ public class PlayerControls : MonoBehaviour
         }
     }
 
+    public void SetComboHighlightForAllButtonsAfterSpecial(bool isMyCombo)
+    {
+        foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
+        {
+            var button = GetButtonByType(type);
+            if (type != Move.Type.Special)
+            {
+                button.SetMyComboIndicator(isMyCombo);
+            }
+            else
+            {
+                button.ClearComboIndicator();
+            }
+        }
+    }
+
     public void ClearComboHighlights()
     {
         foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))

--- a/Assets/Scripts/Gameplay/UI/PlayerControls.cs
+++ b/Assets/Scripts/Gameplay/UI/PlayerControls.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 using Zenject;
 
 public class PlayerControls : MonoBehaviour
-{ 
+{
     private IDatabase _database;
 
     [SerializeField] private MoveButton _lightAttackButton;
@@ -50,9 +50,14 @@ public class PlayerControls : MonoBehaviour
 
     public void SetComboHighlight(Move.Type comboMoveType, bool isMyCombo)
     {
-        foreach(Move.Type type in Enum.GetValues(typeof(Move.Type)))
+        foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
         {
             var button = GetButtonByType(type);
+            if (button == null)
+            {
+                continue;
+            }
+
             if (type == comboMoveType)
             {
                 button.SetMyComboIndicator(isMyCombo);
@@ -69,6 +74,11 @@ public class PlayerControls : MonoBehaviour
         foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
         {
             var button = GetButtonByType(type);
+            if (button == null)
+            {
+                continue;
+            }
+
             if (type != Move.Type.Special)
             {
                 button.SetMyComboIndicator(isMyCombo);

--- a/Assets/Scripts/Gameplay/UI/PlayerControls.cs
+++ b/Assets/Scripts/Gameplay/UI/PlayerControls.cs
@@ -1,3 +1,4 @@
+using System;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.UI;
@@ -45,5 +46,21 @@ public class PlayerControls : MonoBehaviour
     public void ToggleHelperArrows()
     {
         _helperArrows.SetActive(!_helperArrows.activeSelf);
+    }
+
+    public void SetComboHighlight(Move.Type comboMoveType, bool isMyCombo)
+    {
+        foreach(Move.Type type in Enum.GetValues(typeof(Move.Type)))
+        {
+            var button = GetButtonByType(type);
+            if (type == comboMoveType)
+            {
+                button.SetMyComboIndicator(isMyCombo);
+            }
+            else
+            {
+                button.ClearComboIndicator();
+            }
+        }
     }
 }

--- a/Assets/Scripts/Gameplay/UI/PlayerControls.cs
+++ b/Assets/Scripts/Gameplay/UI/PlayerControls.cs
@@ -63,4 +63,13 @@ public class PlayerControls : MonoBehaviour
             }
         }
     }
+
+    public void ClearComboHighlights()
+    {
+        foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
+        {
+            var button = GetButtonByType(type);
+            button.ClearComboIndicator();
+        }
+    }
 }

--- a/Assets/Tests/Core/UsableMoveSetTest.cs
+++ b/Assets/Tests/Core/UsableMoveSetTest.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using Unity.Netcode;
 using System;
+using System.Linq;
 
 public class UsableMoveSetTest
 {
@@ -40,6 +41,10 @@ public class UsableMoveSetTest
         _initialCheckByte = 0;
         foreach (Move.Type type in moveTypeList)
         {
+            if (type == Move.Type.None)
+            {
+                continue;
+            }
             byte isUsable = (byte)(moveSet.GetMoveByType(type).UsableByDefault ? 1 : 0);
             byte typeAsByte = (byte)type;
             _initialCheckByte |= (byte)(typeAsByte * isUsable);


### PR DESCRIPTION
Adds a simple visual element to the move buttons to display the local/opponent player's next combo move. Required the addition of a "None" type to the `enum Move.Type`, and addition of next combo move types to the `TurnResult` struct in order to give visibility of the combo to both the host and the client.