### PR TITLE
Revise combo paths

### DIFF
--- a/Assets/Level/Characters/1_Character/1_ComboPath_Grab.asset
+++ b/Assets/Level/Characters/1_Character/1_ComboPath_Grab.asset
@@ -12,7 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 1_ComboPath_Grab
   m_EditorClassIdentifier: 
-  _comboMove: 8
-  _freshComboMove: 16
-  _mixUp: 04
-  _freshMixUp: 0802
+  _comboMove: 16
+  _freshComboMove: 8

--- a/Assets/Level/Characters/1_Character/1_ComboPath_Parry.asset
+++ b/Assets/Level/Characters/1_Character/1_ComboPath_Parry.asset
@@ -13,6 +13,4 @@ MonoBehaviour:
   m_Name: 1_ComboPath_Parry
   m_EditorClassIdentifier: 
   _comboMove: 16
-  _freshComboMove: 8
-  _mixUp: 0802
-  _freshMixUp: 04
+  _freshComboMove: 16

--- a/Assets/Level/Characters/2_Character/2_ComboPath_Grab.asset
+++ b/Assets/Level/Characters/2_Character/2_ComboPath_Grab.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: 2_ComboPath_Grab
   m_EditorClassIdentifier: 
   _comboMove: 2
-  _freshComboMove: 16
+  _freshComboMove: 8

--- a/Assets/Level/Characters/2_Character/2_ComboPath_Parry.asset
+++ b/Assets/Level/Characters/2_Character/2_ComboPath_Parry.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 2_ComboPath_Parry
   m_EditorClassIdentifier: 
-  _comboMove: 8
+  _comboMove: 16
   _freshComboMove: 16

--- a/Assets/Level/Characters/3_Character/3_ComboPath_Heavy.asset
+++ b/Assets/Level/Characters/3_Character/3_ComboPath_Heavy.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: 3_ComboPath_Heavy
   m_EditorClassIdentifier: 
   _comboMove: 16
-  _freshComboMove: 16
+  _freshComboMove: 2

--- a/Assets/Level/Characters/3_Character/3_ComboPath_Parry.asset
+++ b/Assets/Level/Characters/3_Character/3_ComboPath_Parry.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1febc245a1a102e42aa5de53c5377d7c, type: 3}
   m_Name: 3_ComboPath_Parry
   m_EditorClassIdentifier: 
-  _comboMove: 2
+  _comboMove: 16
   _freshComboMove: 16

--- a/Assets/Scripts/Gameplay/UI/GameUIManager.cs
+++ b/Assets/Scripts/Gameplay/UI/GameUIManager.cs
@@ -99,7 +99,7 @@ public class GameUIManager : NetworkBehaviour, IGameUIManager
         }
         else
         {
-            _playerControls.ClearComboHighlights();
+            _playerControls.ClearAllComboHighlights();
         }
     }
 

--- a/Assets/Scripts/Gameplay/UI/PlayerControls.cs
+++ b/Assets/Scripts/Gameplay/UI/PlayerControls.cs
@@ -90,11 +90,15 @@ public class PlayerControls : MonoBehaviour
         }
     }
 
-    public void ClearComboHighlights()
+    public void ClearAllComboHighlights()
     {
         foreach (Move.Type type in Enum.GetValues(typeof(Move.Type)))
         {
             var button = GetButtonByType(type);
+            if (button == null)
+            {
+                continue;
+            }
             button.ClearComboIndicator();
         }
     }

--- a/Assets/Tests/Gameplay/TurnTest.cs
+++ b/Assets/Tests/Gameplay/TurnTest.cs
@@ -241,10 +241,10 @@ public class TurnTest
                 [Test]
                 [TestCase(Move.Type.LightAttack, Move.Type.HeavyAttack, true, ComboType.Combo)] //fresh combo
                 [TestCase(Move.Type.LightAttack, Move.Type.Parry, true, ComboType.MixUp)] //fresh mixup
-                [TestCase(Move.Type.Grab, Move.Type.HeavyAttack, false, ComboType.Combo)] //not fresh combo
-                [TestCase(Move.Type.Grab, Move.Type.Parry, false, ComboType.MixUp)] //not fresh mixup
-                [TestCase(Move.Type.Grab, Move.Type.Parry, true, ComboType.Normal)] //fresh normal
-                [TestCase(Move.Type.Grab, Move.Type.Grab, false, ComboType.Normal)] //not fresh normal
+                [TestCase(Move.Type.Grab, Move.Type.LightAttack, false, ComboType.Combo)] //not fresh combo
+                [TestCase(Move.Type.Grab, Move.Type.Grab, false, ComboType.MixUp)] //not fresh mixup
+                [TestCase(Move.Type.Grab, Move.Type.Grab, true, ComboType.Normal)] //fresh normal
+                [TestCase(Move.Type.Grab, Move.Type.Parry, false, ComboType.Normal)] //not fresh normal
                 public void ForGivenLastMoveAndCurrentMoveAndFreshness(Move.Type lastMove, Move.Type currentMove, bool isFresh, ComboType expected)
                 {
                     _player1Mock.Setup(m => m.ComboIsFresh).Returns(isFresh);
@@ -318,10 +318,10 @@ public class TurnTest
                 [Test]
                 [TestCase(Move.Type.LightAttack, Move.Type.HeavyAttack, true, ComboType.Combo)] //fresh combo
                 [TestCase(Move.Type.LightAttack, Move.Type.Parry, true, ComboType.MixUp)] //fresh mixup
-                [TestCase(Move.Type.Grab, Move.Type.HeavyAttack, false, ComboType.Combo)] //not fresh combo
-                [TestCase(Move.Type.Grab, Move.Type.Parry, false, ComboType.MixUp)] //not fresh mixup
-                [TestCase(Move.Type.Grab, Move.Type.Parry, true, ComboType.Normal)] //fresh normal
-                [TestCase(Move.Type.Grab, Move.Type.Grab, false, ComboType.Normal)] //not fresh normal
+                [TestCase(Move.Type.Grab, Move.Type.LightAttack, false, ComboType.Combo)] //not fresh combo
+                [TestCase(Move.Type.Grab, Move.Type.Grab, false, ComboType.MixUp)] //not fresh mixup
+                [TestCase(Move.Type.Grab, Move.Type.Grab, true, ComboType.Normal)] //fresh normal
+                [TestCase(Move.Type.Grab, Move.Type.Parry, false, ComboType.Normal)] //not fresh normal
                 public void ForGivenLastMoveAndCurrentMoveAndFreshness(Move.Type lastMove, Move.Type currentMove, bool isFresh, ComboType expected)
                 {
                     _player2Mock.Setup(m => m.ComboIsFresh).Returns(isFresh);


### PR DESCRIPTION
Combo paths were reviewed to find instances where the mix-up option combo'd back into the original option, creating an unsatisfying loop. In general, this meant some degree of homogenization of the "Fresh" combo options across the three characters, but the individual combo path sets retained enough variety, especially with the different focus moves, to remain unique.